### PR TITLE
Create a set of quick check tests

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -18,7 +18,9 @@ To set up a copy of this project for development,
 
 ## Running Tests
 
-To run the project's test suite, run `pytest hlink/tests` in the root project directory.
+To run the project's test suite, run `pytest hlink/tests` in the root project directory. Running all of the tests
+can take a while, depending on your computer's hardware and setup. To run a subset of tests that test some but not
+all of the core features, try `pytest hlink/tests -m quickcheck`. These tests should run much more quickly.
 
 ## Building the Scala Jar
 

--- a/hlink/tests/config_loader_test.py
+++ b/hlink/tests/config_loader_test.py
@@ -11,6 +11,7 @@ import os.path
 import pytest
 
 
+@pytest.mark.quickcheck
 def test_load_conf_file_json(package_path):
     conf_path = os.path.join(package_path, "conf")
     conf_file = os.path.join(conf_path, "test")
@@ -18,6 +19,7 @@ def test_load_conf_file_json(package_path):
     assert conf["id_column"] == "id"
 
 
+@pytest.mark.quickcheck
 def test_load_conf_file_toml(package_path):
     conf_path = os.path.join(package_path, "conf")
     conf_file = os.path.join(conf_path, "test1")
@@ -25,6 +27,7 @@ def test_load_conf_file_toml(package_path):
     assert conf["id_column"] == "id-toml"
 
 
+@pytest.mark.quickcheck
 def test_load_conf_file_nested(package_path):
     running_path = package_path.rpartition("hlink/tests")[0]
     conf_name = "hlink_config/config/test_conf_flag_run"

--- a/hlink/tests/main_loop_test.py
+++ b/hlink/tests/main_loop_test.py
@@ -11,6 +11,7 @@ from pyspark.ml.feature import VectorAssembler, OneHotEncoderEstimator
 from hlink.linking.link_run import link_task_choices
 
 
+@pytest.mark.quickcheck
 def test_do_get_steps(capsys, main, spark):
     for task in link_task_choices:
         task_inst = getattr(main.link_run, task)
@@ -26,6 +27,7 @@ def test_do_get_steps(capsys, main, spark):
             assert str(step) in output
 
 
+@pytest.mark.quickcheck
 def test_do_set_link_task(capsys, main):
     main.current_link_task = main.link_run.matching
     main.do_set_link_task("preprocessing")

--- a/hlink/tests/main_test.py
+++ b/hlink/tests/main_test.py
@@ -60,6 +60,7 @@ def test_load_conf_does_not_exist_no_env(monkeypatch, tmp_path, conf_file, user)
         load_conf(filename, user)
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("conf_file", ("my_conf.json",))
 @pytest.mark.parametrize("user", users)
 def test_load_conf_json_exists_no_env(monkeypatch, tmp_path, conf_file, user):
@@ -90,6 +91,7 @@ def test_load_conf_json_exists_ext_added_no_env(monkeypatch, tmp_path, conf_name
     assert conf["conf_path"] == filename
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("conf_file", ("my_conf.toml",))
 @pytest.mark.parametrize("user", users)
 def test_load_conf_toml_exists_no_env(monkeypatch, tmp_path, conf_file, user):
@@ -188,6 +190,7 @@ def test_load_conf_does_not_exist_env(
         load_conf(conf_file, user)
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("conf_file", ("my_conf.json",))
 @pytest.mark.parametrize("user", users)
 def test_load_conf_json_exists_in_conf_dir_env(
@@ -207,6 +210,7 @@ def test_load_conf_json_exists_in_conf_dir_env(
     assert conf["conf_path"] == str(file)
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("conf_file", ("my_conf.toml",))
 @pytest.mark.parametrize("user", users)
 def test_load_conf_toml_exists_in_conf_dir_env(

--- a/hlink/tests/matching_blocking_explode_test.py
+++ b/hlink/tests/matching_blocking_explode_test.py
@@ -3,10 +3,12 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import pytest
 import pandas as pd
 from hlink.linking.matching.link_step_score import LinkStepScore
 
 
+@pytest.mark.quickcheck
 def test_steps_1_2_matching(
     spark, blocking_explode_conf, matching_test_input, matching, main
 ):

--- a/hlink/tests/preprocessing_test.py
+++ b/hlink/tests/preprocessing_test.py
@@ -10,6 +10,7 @@ from pyspark.sql.types import StructType, StructField, LongType
 from hlink.errors import DataError
 
 
+@pytest.mark.quickcheck
 def test_step_0(preprocessing, spark, preprocessing_conf):
     """ Test preprocessing step 0 to ensure that temporary raw_df_unpartitioned_(a/b) tables are created (exact copies of datasources from config). Also test that the presistent raw_df_(a/b) tables are created. Should be same as raw datasources with filters applied"""
 

--- a/hlink/tests/table_test.py
+++ b/hlink/tests/table_test.py
@@ -8,12 +8,14 @@ def simple_schema():
     return StructType([StructField("test", StringType())])
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("table_name", ["this_table_does_not_exist", "@@@", "LOL rofl"])
 def test_exists_table_does_not_exist(spark, table_name):
     t = Table(spark, table_name, "table used for testing")
     assert not t.exists()
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("table_name", ["table_for_testing_Table_class"])
 def test_exists_table_does_exist(spark, table_name, simple_schema):
     t = Table(spark, table_name, "table used for testing")
@@ -23,6 +25,7 @@ def test_exists_table_does_exist(spark, table_name, simple_schema):
     spark.sql(f"DROP TABLE {table_name}")
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("table_name", ["table_for_testing_Table_class"])
 def test_drop_table_does_exist(spark, table_name, simple_schema):
     t = Table(spark, table_name, "table used for testing")
@@ -42,6 +45,7 @@ def test_drop_table_does_not_exist(spark, table_name):
     assert not t.exists()
 
 
+@pytest.mark.quickcheck
 @pytest.mark.parametrize("table_name", ["table_for_testing_Table_class"])
 def test_df_table_does_exist(spark, table_name, simple_schema):
     t = Table(spark, table_name, "table used for testing")

--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -3,10 +3,12 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import pytest
 from pyspark.ml import Pipeline
 import hlink.linking.core.pipeline as pipeline_core
 
 
+@pytest.mark.quickcheck
 def test_all_steps(
     spark,
     training_conf,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    quickcheck: add a test to a list of tests that run quickly and test important features


### PR DESCRIPTION
These tests can be run with `pytest hlink/tests -m quickcheck` and are a lot faster to complete than running all of the tests. This is nice to have for development and quickly checking that the core functionality isn't broken.

I added a note to `developer.md` about the quick check tests too.