### PR TITLE
Improve logging

### DIFF
--- a/hlink/linking/link_task.py
+++ b/hlink/linking/link_task.py
@@ -58,13 +58,16 @@ class LinkTask(object):
 
     def run_all_steps(self):
         """Run all steps in order."""
+        logging.info(f"Running all steps for task {self.display_name}")
         start_all = timer()
         for (i, step) in enumerate(self.get_steps()):
             print(f"Running step {i}: {step}")
+            logging.info(f"Running step {i}: {step}")
             step.run()
         end_all = timer()
         elapsed_time_all = round(end_all - start_all, 2)
         print(f"Finished all in {elapsed_time_all}s")
+        logging.info(f"Finished all steps in {elapsed_time_all}s")
 
     def run_step(self, step_num: int):
         """Run a particular step.

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -99,8 +99,8 @@ def cli():
         traceback.print_exception("", err, None)
         sys.exit(1)
 
-    spark = _get_spark(run_conf, args)
     _setup_logging(run_conf)
+    spark = _get_spark(run_conf, args)
     history_file = os.path.expanduser("~/.history_hlink")
     _read_history_file(history_file)
 

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -242,6 +242,8 @@ def _setup_logging(conf):
     log_file = conf["log_file"]
     user = getpass.getuser()
     session_id = uuid.uuid4().hex
+    hlink_version = pkg_resources.get_distribution("hlink").version
+
     # format_string = f"%(levelname)s %(asctime)s {user} {session_id} %(message)s -- {conf['conf_path']}"
     format_string = "%(levelname)s %(asctime)s -- %(message)s"
     print(f"*** Hlink log: {log_file}")
@@ -254,6 +256,7 @@ def _setup_logging(conf):
     )
     logging.info(f"   New Session {session_id} by user {user} ")
     logging.info(f"   Configured with  {conf['conf_path']}")
+    logging.info(f"   Running hlink version {hlink_version}")
     logging.info(
         "-------------------------------------------------------------------------------------"
     )

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -15,6 +15,7 @@ import readline
 import sys
 import traceback
 import uuid
+from timeit import default_timer as timer
 
 from hlink.spark.session import SparkConnection
 from hlink.configs.load_config import load_conf_file
@@ -100,7 +101,14 @@ def cli():
         sys.exit(1)
 
     _setup_logging(run_conf)
+
+    logging.info("Initializing spark")
+    spark_init_start = timer()
     spark = _get_spark(run_conf, args)
+    spark_init_end = timer()
+    spark_init_time = round(spark_init_end - spark_init_start, 2)
+    logging.info(f"Initialized spark in {spark_init_time}s")
+
     history_file = os.path.expanduser("~/.history_hlink")
     _read_history_file(history_file)
 

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -102,12 +102,12 @@ def cli():
 
     _setup_logging(run_conf)
 
-    logging.info("Initializing spark")
+    logging.info("Initializing Spark")
     spark_init_start = timer()
     spark = _get_spark(run_conf, args)
     spark_init_end = timer()
     spark_init_time = round(spark_init_end - spark_init_start, 2)
-    logging.info(f"Initialized spark in {spark_init_time}s")
+    logging.info(f"Initialized Spark in {spark_init_time}s")
 
     history_file = os.path.expanduser("~/.history_hlink")
     _read_history_file(history_file)
@@ -216,7 +216,7 @@ def _cli_loop(spark, args, run_conf):
         logging.info("Analyzed config file, no errors found")
     except ValueError as err:
         logging.error(
-            "analyze_conf() found an error in the config file. See below for details."
+            "Analysis found an error in the config file. See below for details."
         )
         report_and_log_error("", err)
 
@@ -266,9 +266,9 @@ def _setup_logging(conf):
     logging.info(
         "-------------------------------------------------------------------------------------"
     )
-    logging.info(f"   New Session {session_id} by user {user} ")
-    logging.info(f"   Configured with  {conf['conf_path']}")
-    logging.info(f"   Running hlink version {hlink_version}")
+    logging.info(f"   New session {session_id} by user {user}")
+    logging.info(f"   Configured with {conf['conf_path']}")
+    logging.info(f"   Using hlink version {hlink_version}")
     logging.info(
         "-------------------------------------------------------------------------------------"
     )

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -205,7 +205,11 @@ def _cli_loop(spark, args, run_conf):
     try:
         print("Analyzing config file")
         analyze_conf(LinkRun(spark, run_conf))
+        logging.info("Analyzed config file, no errors found")
     except ValueError as err:
+        logging.error(
+            "analyze_conf() found an error in the config file. See below for details."
+        )
         report_and_log_error("", err)
 
     while True:


### PR DESCRIPTION
This PR improves some logging in hlink. The logging should help provide context when running the `hlink` command and trying to diagnose issues or find bugs. There's now logging for the `LinkTask.run_all_steps()` method, Spark initialization, and the initial config file analysis. Hlink's current version now also appears in the logging header.