### PR TITLE
Fix a bug where the hlink command would crash on startup

### DIFF
--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -251,7 +251,9 @@ def _reload_modules():
 
 
 def _setup_logging(conf):
-    log_file = conf["log_file"]
+    log_file = Path(conf["log_file"])
+    log_file.parent.mkdir(exist_ok=True, parents=True)
+
     user = getpass.getuser()
     session_id = uuid.uuid4().hex
     hlink_version = pkg_resources.get_distribution("hlink").version


### PR DESCRIPTION
This happened when the parent directory of the logging file didn't exist. This bug was introduced by the recent logging changes I made. It didn't happen before because the Spark initialization code would always create the directory that the logging file was in. But now it shows up because we're setting up logging before initializing Spark.