### PR TITLE
Adjust Spark partitions based on dataset size for several link steps

### DIFF
--- a/hlink/linking/matching/link_step_score.py
+++ b/hlink/linking/matching/link_step_score.py
@@ -40,18 +40,18 @@ class LinkStepScore(LinkStep):
             )
             return
 
-        id_a = config["id_column"] + "_a"
-        id_b = config["id_column"] + "_b"
-        chosen_model_params = config[training_conf]["chosen_model"].copy()
-        self._create_features(config)
-        pm = self.task.spark.table(f"{table_prefix}potential_matches_prepped")
-
-        dataset_size = pm.count()
+        dataset_size = self.task.spark.table(f"{table_prefix}potential_matches").count()
         num_partitions = spark_shuffle_partitions_heuristic(dataset_size)
         self.task.spark.sql(f"set spark.sql.shuffle.partitions={num_partitions}")
         logging.info(
             f"Dataset size is {dataset_size}, so set Spark partitions to {num_partitions} for this step"
         )
+
+        id_a = config["id_column"] + "_a"
+        id_b = config["id_column"] + "_b"
+        chosen_model_params = config[training_conf]["chosen_model"].copy()
+        self._create_features(config)
+        pm = self.task.spark.table(f"{table_prefix}potential_matches_prepped")
 
         ind_var_columns = config[training_conf]["independent_vars"]
         flatten = lambda l: [item for sublist in l for item in sublist]

--- a/hlink/linking/preprocessing/link_step_prep_dataframes.py
+++ b/hlink/linking/preprocessing/link_step_prep_dataframes.py
@@ -3,11 +3,13 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import logging
 from pyspark.sql.functions import col
 
 import hlink.linking.core.column_mapping as column_mapping_core
 import hlink.linking.core.substitutions as substitutions_core
 import hlink.linking.core.transforms as transforms_core
+from hlink.linking.util import spark_shuffle_partitions_heuristic
 
 from hlink.linking.link_step import LinkStep
 
@@ -23,6 +25,15 @@ class LinkStepPrepDataframes(LinkStep):
 
     def _run(self):
         config = self.task.link_run.config
+
+        dataset_size_a = self.task.spark.table("raw_df_a").count()
+        dataset_size_b = self.task.spark.table("raw_df_b").count()
+        dataset_size_max = max(dataset_size_a, dataset_size_b)
+        num_partitions = spark_shuffle_partitions_heuristic(dataset_size_max)
+        self.task.spark.sql(f"set spark.sql.shuffle.partitions={num_partitions}")
+        logging.info(
+            f"Dataset sizes are A={dataset_size_a}, B={dataset_size_b}, so set Spark partitions to {num_partitions} for this step"
+        )
 
         substitution_columns = config.get("substitution_columns", [])
         self.task.run_register_python(


### PR DESCRIPTION
This PR adds some logic to automatically adjust the number of Spark partitions based on the size of input datasets to some link steps. This should help these steps to scale well for large datasets where the default number of 200 partitions won't do.

`hlink.linking.util.spark_shuffle_partitions_heuristic()` is responsible for computing the number of partitions to use based on the size of the input dataset(s). I accidentally committed this function straight to the main branch, so check out the latest commit over there too.

The minimum number of partitions that `spark_shuffle_partitions_heuristic()` returns is 200, and each of these link steps resets the number of partitions to 200 when it finishes. So this shouldn't affect other link steps or negatively affect performance for small datasets.

I've added some logging so that it's easy to tell how many partitions are being used for these link steps.