### PR TITLE
Upgrade to Spark 3.3.0

### DIFF
--- a/hlink/linking/core/transforms.py
+++ b/hlink/linking/core/transforms.py
@@ -358,7 +358,7 @@ def generate_transforms(
         if attach_ts:
             attach_hh_column = spark._jvm.com.isrdi.udfs.AttachHHColumn()
             attach_hh_column.createAttachUDF(
-                spark._jwrapped, df_grouped._jdf, attach_ts, "attach_hh_scala"
+                spark._jsparkSession, df_grouped._jdf, attach_ts, "attach_hh_scala"
             )
             all_cols_but_hh_rows = list(set(df_grouped.columns) - set(["hh_rows"]))
             df_grouped_selects = all_cols_but_hh_rows + [
@@ -369,7 +369,7 @@ def generate_transforms(
             attach_rel_rows = spark._jvm.com.isrdi.udfs.AttachRelatedRows()
             a_or_b = "a" if is_a else "b"
             attach_rel_rows.createAttachUDF(
-                spark._jwrapped,
+                spark._jsparkSession,
                 df_grouped._jdf,
                 related_ts,
                 id_col,

--- a/scala_jar/build.sbt
+++ b/scala_jar/build.sbt
@@ -31,8 +31,8 @@ version := "1.0"
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
   "org.apache.commons" % "commons-text" % "1.9",
-  "org.apache.spark" % "spark-sql_2.12" % "3.2.1" % "provided",
-  "org.apache.spark" % "spark-mllib_2.12" % "3.2.1" % "provided"
+  "org.apache.spark" % "spark-sql_2.12" % "3.3.0" % "provided",
+  "org.apache.spark" % "spark-mllib_2.12" % "3.3.0" % "provided"
  )
 
 // Here, `libraryDependencies` is a set of dependencies, and by using `+=`,

--- a/scala_jar/src/main/scala/com/isrdi/udfs/AttachHHColumn.scala
+++ b/scala_jar/src/main/scala/com/isrdi/udfs/AttachHHColumn.scala
@@ -13,14 +13,14 @@ import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types._
 import scala.util.control.Breaks._
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import scala.math.abs
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 class AttachHHColumn {
-  def createAttachUDF(spark: SQLContext, df: Dataset[Row], transforms: java.util.List[java.util.Map[String, String]], udf_name: String ) = {
+  def createAttachUDF(spark: SparkSession, df: Dataset[Row], transforms: java.util.List[java.util.Map[String, String]], udf_name: String ) = {
     val person_id = transforms.get(0).get("person_id")
     val attach_udf = (hh_rows: Seq[Row]) => {
       val hh_map = hh_rows.map { row => row.getAs[Any](person_id) -> row }.toMap

--- a/scala_jar/src/main/scala/com/isrdi/udfs/AttachRelatedRows.scala
+++ b/scala_jar/src/main/scala/com/isrdi/udfs/AttachRelatedRows.scala
@@ -13,14 +13,14 @@ import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types._
 import scala.util.control.Breaks._
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import scala.math.abs
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 class AttachRelatedRows {
-  def createAttachUDF(spark: SQLContext, df: Dataset[Row], transforms: java.util.List[java.util.Map[String, Any]], id_col: String, a_or_b: String, udf_name: String ) = {
+  def createAttachUDF(spark: SparkSession, df: Dataset[Row], transforms: java.util.List[java.util.Map[String, Any]], id_col: String, a_or_b: String, udf_name: String ) = {
     val attach_udf = (hh_rows: Seq[Row]) => {
       val related_rows_list = transforms.asScala.map { transform =>
         val input_cols = transform.get("input_cols").asInstanceOf[java.util.List[String]].asScala

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     "Jinja2==3.1.2",
     "numpy==1.22.3",
     "pandas==1.4.2",
-    "pyspark==3.2.1",
+    "pyspark==3.3.0",
     "scikit-learn==1.1.0",
     "toml==0.10.2",
 ]


### PR DESCRIPTION
This pull request updates hlink from using pyspark 3.2.1 to pyspark 3.3.0.

None of the items in the [migration guide](https://spark.apache.org/docs/latest/api/python/migration_guide/pyspark_3.2_to_3.3.html) made a big difference for us. The one breaking change that I found is that `SparkSession._jwrapped` was removed. This was a JVM `SQLContext` object which we were passing to the `createAttachUDF()` functions in Scala so that they could register the created UDFs. `SQLContext` has been deprecated and replaced with `SparkSession`, which satisfies the same interface. So I've changed the code to pass `SparkSession._jsparkSession` to Scala and adjusted the Scala argument types.