### PR TITLE
Make config validation id column check case-insensitive

### DIFF
--- a/hlink/scripts/lib/conf_validations.py
+++ b/hlink/scripts/lib/conf_validations.py
@@ -346,5 +346,6 @@ def parse_datasource(link_run, section_name: str):
 
 def check_datasource(config, df, a_or_b):
     id_column = config["id_column"]
-    if id_column not in df.columns:
+    input_columns = map((lambda s: s.lower()), df.columns)
+    if id_column.lower() not in input_columns:
         raise ValueError(f"Datasource {a_or_b} is missing the id column '{id_column}'")


### PR DESCRIPTION
Fixes #39.

This PR lowercases both the id column and the list of datasource column names before checking that the list contains the id column. This prevents spurious errors when there are case differences between the config file and the datasource column names.

Right now this just uses `str.lower()` as much of the rest of hlink does. If we encounter some non-ASCII parquet column names, we may be better off using `str.casefold()` or something more complicated. But this should do for now at least.