### PR TITLE
add toml to fenced code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ matches_df = matches.df()
 
 An example configuration file:
 
-```
+```toml
 ### hlink config file ###
 # This is a sample config file for the hlink program in toml format.
 


### PR DESCRIPTION
Interesting package!

This just adds `toml` to the example configuration to improve the readability on the repo page.