### PR TITLE
Create a separate log file for each run of hlink

### DIFF
--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -31,7 +31,7 @@ def load_conf(conf_name, user):
     """Load and return the hlink config dictionary.
 
     Add the following attributes to the config dictionary:
-    "derby_dir", "warehouse_dir", "spark_tmp_dir", "log_file", "python", "conf_path"
+    "derby_dir", "warehouse_dir", "spark_tmp_dir", "log_dir", "python", "conf_path"
     """
     if "HLINK_CONF" not in os.environ:
         global_conf = None
@@ -53,7 +53,7 @@ def load_conf(conf_name, user):
         conf["derby_dir"] = base_derby_dir / run_name
         conf["warehouse_dir"] = base_warehouse_dir / run_name
         conf["spark_tmp_dir"] = base_spark_tmp_dir / run_name
-        conf["log_file"] = hlink_dir / "run.log"
+        conf["log_dir"] = hlink_dir / "logs"
         conf["python"] = sys.executable
     else:
         user_dir = Path(global_conf["users_dir"]) / user
@@ -65,7 +65,7 @@ def load_conf(conf_name, user):
         conf["derby_dir"] = user_dir / "derby" / run_name
         conf["warehouse_dir"] = user_dir_fast / "warehouse" / run_name
         conf["spark_tmp_dir"] = user_dir_fast / "tmp" / run_name
-        conf["log_file"] = user_dir / "hlink.log"
+        conf["log_dir"] = user_dir / "logs"
         conf["python"] = global_conf["python"]
 
     print(f"*** Using config file {conf['conf_path']}")
@@ -251,8 +251,9 @@ def _reload_modules():
 
 
 def _setup_logging(conf):
-    log_file = Path(conf["log_file"])
-    log_file.parent.mkdir(exist_ok=True, parents=True)
+    log_dir = Path(conf["log_dir"])
+    log_dir.mkdir(exist_ok=True, parents=True)
+    log_file = log_dir / "hlink.log"
 
     user = getpass.getuser()
     session_id = uuid.uuid4().hex

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -253,11 +253,13 @@ def _reload_modules():
 def _setup_logging(conf):
     log_dir = Path(conf["log_dir"])
     log_dir.mkdir(exist_ok=True, parents=True)
-    log_file = log_dir / "hlink.log"
 
     user = getpass.getuser()
     session_id = uuid.uuid4().hex
+    conf_name = Path(conf["conf_path"]).stem
     hlink_version = pkg_resources.get_distribution("hlink").version
+
+    log_file = log_dir / f"{conf_name}-{session_id}.log"
 
     # format_string = f"%(levelname)s %(asctime)s {user} {session_id} %(message)s -- {conf['conf_path']}"
     format_string = "%(levelname)s %(asctime)s -- %(message)s"
@@ -265,14 +267,9 @@ def _setup_logging(conf):
 
     logging.basicConfig(filename=log_file, level=logging.INFO, format=format_string)
 
-    logging.info("")
+    logging.info(f"New session {session_id} by user {user}")
+    logging.info(f"Configured with {conf['conf_path']}")
+    logging.info(f"Using hlink version {hlink_version}")
     logging.info(
         "-------------------------------------------------------------------------------------"
     )
-    logging.info(f"   New session {session_id} by user {user}")
-    logging.info(f"   Configured with {conf['conf_path']}")
-    logging.info(f"   Using hlink version {hlink_version}")
-    logging.info(
-        "-------------------------------------------------------------------------------------"
-    )
-    logging.info("")

--- a/hlink/tests/main_test.py
+++ b/hlink/tests/main_test.py
@@ -159,7 +159,7 @@ def test_load_conf_keys_set_no_env(monkeypatch, tmp_path):
     assert "derby_dir" in conf
     assert "warehouse_dir" in conf
     assert "spark_tmp_dir" in conf
-    assert "log_file" in conf
+    assert "log_dir" in conf
     assert "python" in conf
 
 
@@ -308,5 +308,5 @@ def test_load_conf_keys_set_env(
     assert "derby_dir" in conf
     assert "warehouse_dir" in conf
     assert "spark_tmp_dir" in conf
-    assert "log_file" in conf
+    assert "log_dir" in conf
     assert "python" in conf


### PR DESCRIPTION
Closes #54.

This PR updates hlink's main script to log to a separate file for each run instead of always logging to the same file. The name of the log file is `{conf_name}-{session_id}.log`, where `session_id` is the hexadecimal representation of a uuid generated for the run. Each log file is placed in the same directory, named `logs/`. The location of this `logs/` directory depends on whether a global configuration file is provided with the HLINK_CONF environment variable or not.

This changes `main.load_conf()` so that it adds the key `"log_dir"` to the config dictionary instead of `"log_file"`. This isn't a big deal, as the only other place that uses these keys is `main._setup_logging()`.