### PR TITLE
Adjust `SerJaroWinklerSimilarity` for empty strings

### DIFF
--- a/hlink/tests/scala_udf_test.py
+++ b/hlink/tests/scala_udf_test.py
@@ -21,3 +21,9 @@ def test_jw_matching_strings(spark, left: str, right: str):
 def test_jw_completely_different_strings(spark, left: str, right: str):
     [row] = spark.sql(f"SELECT jw('{left}', '{right}') AS jw_result").collect()
     assert row.jw_result < 0.0001
+
+
+@pytest.mark.parametrize("left,right", [("", "discombobulated"), ("GlyphidMenace", "")])
+def test_jw_one_empty_string(spark, left: str, right: str):
+    [row] = spark.sql(f"SELECT jw('{left}', '{right}') AS jw_result").collect()
+    assert row.jw_result < 0.0001

--- a/hlink/tests/scala_udf_test.py
+++ b/hlink/tests/scala_udf_test.py
@@ -1,0 +1,23 @@
+# This file is part of the ISRDI's hlink.
+# For copyright and licensing information, see the NOTICE and LICENSE files
+# in this project's top-level directory, and also on-line at:
+#   https://github.com/ipums/hlink
+
+import pytest
+
+
+def test_jw_empty_strings(spark):
+    [row] = spark.sql("SELECT jw('', '') AS jw_result").collect()
+    assert row.jw_result < 0.0001
+
+
+@pytest.mark.parametrize("left,right", [("z", "z"), ("ambulate", "ambulate")])
+def test_jw_matching_strings(spark, left: str, right: str):
+    [row] = spark.sql(f"SELECT jw('{left}', '{right}') AS jw_result").collect()
+    assert row.jw_result > 0.9999
+
+
+@pytest.mark.parametrize("left,right", [("zzzzzz", "sleepy"), ("no", "shared letters")])
+def test_jw_completely_different_strings(spark, left: str, right: str):
+    [row] = spark.sql(f"SELECT jw('{left}', '{right}') AS jw_result").collect()
+    assert row.jw_result < 0.0001

--- a/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
+++ b/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
@@ -7,6 +7,15 @@ package com.isrdi.udfs
 import org.apache.commons.text.similarity._
 
 class SerJaroWinklerSimilarity extends JaroWinklerSimilarity with Serializable {
+  // JaroWinklerSimilarity.apply("", "") returns 1.0, but for our use case it makes
+  // more sense for two empty strings to have similarity 0.0.
+  //
+  // By my understanding, the comparison of two empty strings is essentially
+  // undefined. To me it makes sense to directly apply the definition of
+  // Jaro-Winkler similarity to two empty strings and get a similarity of 0.
+  // But this has the unfortunate side effect of making the distance between two
+  // empty strings 1 - 0 = 1. So I understand the decision to make the
+  // similarity 1 and the distance 0 as well.
   override def apply(left: CharSequence, right: CharSequence): java.lang.Double = {
     if (left == "" && right == "") {
       0.0

--- a/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
+++ b/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
@@ -6,4 +6,12 @@
 package com.isrdi.udfs
 import org.apache.commons.text.similarity._
 
-class SerJaroWinklerSimilarity extends JaroWinklerSimilarity with Serializable { }
+class SerJaroWinklerSimilarity extends JaroWinklerSimilarity with Serializable {
+  override def apply(left: CharSequence, right: CharSequence): java.lang.Double = {
+    if (left == "" && right == "") {
+      0.0
+    } else {
+      super.apply(left, right)
+    }
+  }
+}

--- a/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
+++ b/scala_jar/src/main/scala/com/isrdi/udfs/SerJaroWinklerSimilarity.scala
@@ -7,8 +7,10 @@ package com.isrdi.udfs
 import org.apache.commons.text.similarity._
 
 class SerJaroWinklerSimilarity extends JaroWinklerSimilarity with Serializable {
-  // JaroWinklerSimilarity.apply("", "") returns 1.0, but for our use case it makes
-  // more sense for two empty strings to have similarity 0.0.
+  // If either input string is empty, immediately return 0. Otherwise, return
+  // the value of calling JaroWinklerSimilarity's apply function.
+  // JaroWinklerSimilarity.apply("", "") returns 1, but for our use case it makes
+  // more sense for two empty strings to have similarity 0.
   //
   // By my understanding, the comparison of two empty strings is essentially
   // undefined. To me it makes sense to directly apply the definition of
@@ -17,7 +19,7 @@ class SerJaroWinklerSimilarity extends JaroWinklerSimilarity with Serializable {
   // empty strings 1 - 0 = 1. So I understand the decision to make the
   // similarity 1 and the distance 0 as well.
   override def apply(left: CharSequence, right: CharSequence): java.lang.Double = {
-    if (left == "" && right == "") {
+    if (left == "" || right == "") {
       0.0
     } else {
       super.apply(left, right)


### PR DESCRIPTION
Closes #56.

This pull request fixes a bug that we introduced when we upgraded the Scala library we use to compute Jaro-Winkler scores. During the upgrade, the similarity of two empty strings changed from 0 to 1. We want the similarity to be 0, so these changes introduce a check for empty strings in `SerJaroWinklerSimilarity` before calling `JaroWinklerSimilarity` from the library.

This also adds some tests for edge cases in the `jw` user-defined function that we use in Spark SQL.