### PR TITLE
Get the tutorial up and running

### DIFF
--- a/examples/tutorial/.gitignore
+++ b/examples/tutorial/.gitignore
@@ -1,0 +1,2 @@
+spark/
+potential_matches.csv

--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -23,21 +23,27 @@ dataset A to be aged 50 in dataset B.
 
 ## The Config File and Linking Strategy
 
-To link these two datasets, we a configuration file that directs
+To link these two datasets, we need a configuration file that directs
 hlink on what operations to perform and how to determine when a link is found. For
 our tutorial example, we'll use deterministic linking, but hlink is also capable
 of using machine learning models to classify possible links between the datasets.
 
 In this section we'll walk through the process of creating the tutorial\_config.toml
 file that can be found in this directory. Creating a config file can be complicated.
-See the hlink documentation for a detailed explanation of the different config
-file sections and keys.
+See the [hlink documentation](https://hlink.docs.ipums.org) for a detailed
+explanation of the different config file sections and keys.
 
 The first step in creating a config file is describing the data to hlink. The
 `id_column` key tells hlink the name of the id column which uniquely identifies
 each record in a dataset. In our case, this is "ID". The `datasource_a`
 and `datasource_b` sections give hlink information about where to find the input
-files. We give hlink the relative path to our data files in these sections.
+files. We give hlink the relative path to our data files in these sections. Each
+column that we want to read from the dataset files into hlink must appear in a
+`column_mappings` section. By default a `column_mappings` section reads in the
+column unchanged, but it can also be used to perform some preprocessing and
+cleaning on the column as it is read in. In our config file, we have hlink
+lowercase names and strip leading and trailing whitespace to support comparability
+between the datasets.
 
 After describing the data to hlink, we need to think about our linking strategy.
 How will we determine who links between the two datasets? Do we need to do any
@@ -76,13 +82,6 @@ threshold of 0.84. If a single record pair reaches both thresholds, then we call
 it a link! This pair of records will end up in `potential_matches.csv` when the
 script completes.
 
-In the real world, it's very likely that the names in dataset A and dataset B
-are not consistently formatted. This is where the `column_mappings` section
-comes in. It tells hlink to perform some data cleaning in the preprocessing step
-before matching occurs. The column mappings in the tutorial config file strip
-whitespace from the names and lowercase them to remove discrepancies in formatting
-between the two datasets.
-
 Now that the config file is written, we can run hlink to generate some links. See
 the next section for a description of the tutorial script that runs hlink.
 
@@ -93,11 +92,11 @@ hlink to generate potential matches between the two datasets. It creates a `Link
 which is the main way to control the hlink library. After analyzing the
 config file for errors, it runs two link tasks: preprocessing and matching.
 
-The preprocessing task reads the data from the datasets in and does the data
+The preprocessing task reads in the data from the datasets and does the data
 cleaning and column mapping that we've asked it to do for us in the config file.
 
 The matching task does the real linking work, finding links between the two datasets.
-It stores its results in a `potential_matches` spark table. The script saves this
+It stores its results in a `potential_matches` Spark table. The script saves this
 table to the `potential_matches.csv` file and prints it to the screen.
 
 ## Getting and Interpreting Results
@@ -113,10 +112,10 @@ that they look reasonable. Some links may be more reasonable than others!
 
 - After running the tutorial script once, run it again. This time it should print
 statements like `Preexisting table: raw_df_a`. If hlink finds that a Spark table
-already exists when it goes to compute it, it will use the pre-existing table
+already exists when it goes to compute it, it will use the preexisting table
 instead of recomputing it. To prevent this from happening, try passing the
 `--clean` argument to tutorial.py. This will tell the script to drop all of the
-pre-existing tables before it runs the linking job.
+preexisting tables before it runs the linking job.
 
 - Try increasing or decreasing the Jaro-Winkler thresholds in the config file.
 How does this affect the matches that are generated?

--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -1,29 +1,41 @@
-# HLink Tutorial
+# hlink Tutorial
 
 This is an example linking project that uses hlink to link people between two
-datasets, `data/A.csv` and `data/B.csv`. Note that these datasets are not
-included, so the example script will throw an error if run out of the box.
+very small example datasets, data/A.csv and data/B.csv. After installing hlink,
+the tutorial can be run as `python tutorial.py` in this directory. This will
+perform the matching and generate a list of potential matches between dataset A
+and dataset B. These potential matches are printed to the screen and are also
+saved to the file potential\_matches.csv.
 
 ## Dataset Overview
 
-The tutorial script supposes that each of the datasets has the following columns:
-id, NAMEFRST, NAMELAST, AGE, SEX. In addition, it supposes that dataset B was
-created 10 years after dataset A. Each record in the datasets represents a single
-person.
+Each of the datasets has the following columns:
+- ID (unique numeric identifier)
+- NAMEFRST (first name)
+- NAMELAST (last name)
+- AGE
+- SEX
+
+These datasets are fictional example datasets. Each record in the datasets
+represents a single person at a point in time. Dataset A models data sampled 10
+years before dataset B's data was sampled. So we would expect someone aged 40 in
+dataset A to be aged 50 in dataset B.
 
 ## The Config File and Linking Strategy
 
-To link these two datasets, we need to create a configuration file that directs
+To link these two datasets, we a configuration file that directs
 hlink on what operations to perform and how to determine when a link is found. For
 our tutorial example, we'll use deterministic linking, but hlink is also capable
 of using machine learning models to classify possible links between the datasets.
 
-Creating a config file is complicated. See the hlink documentation for a
-more detailed explanation of the different config file sections and keys.
+In this section we'll walk through the process of creating the tutorial\_config.toml
+file that can be found in this directory. Creating a config file can be complicated.
+See the hlink documentation for a detailed explanation of the different config
+file sections and keys.
 
 The first step in creating a config file is describing the data to hlink. The
 `id_column` key tells hlink the name of the id column which uniquely identifies
-each record in the databases. In our case, this is just "id". The `datasource_a`
+each record in a dataset. In our case, this is "ID". The `datasource_a`
 and `datasource_b` sections give hlink information about where to find the input
 files. We give hlink the relative path to our data files in these sections.
 
@@ -37,9 +49,10 @@ In our tutorial example, here is the general linking strategy that we'll use:
 A and B.
 - We say that two records may link only if the difference between AGE in A and
 AGE in B is within 2 years of 10, so 8 to 12.
-- Finally, we use the Jaro-Winkler string comparison algorithm to compare each
-candidate link's NAMEFRST and NAMELAST between the two datasets. If the names score
-sufficiently high, then we have a link!
+- Finally, we use the
+[Jaro-Winkler string comparison algorithm](https://en.wikipedia.org/wiki/Jaro–Winkler_distance)
+to compare each candidate link's NAMEFRST and NAMELAST between the two datasets.
+If the names score sufficiently high, then we have a link!
 
 The first two bullet points above correspond to the `blocking` section. In this
 section, we separate records into different *blocks*. Then each record may link
@@ -56,27 +69,28 @@ with an AGE anywhere from 8 to 12 years greater than the AGE in dataset A.
 
 The last bullet point corresponds to the `comparison_features` and `comparisons`
 sections. In these sections, we tell hlink to compute the Jaro-Winkler score
-between the NAMEFRST string in the dataset A record and the corresponding string
+between the NAMEFRST string in the dataset A record and the NAMEFRST string
 in the dataset B record, then compare the score against a threshold of 0.79 to
 determine if it's a link or not. We do the same thing for NAMELAST, with a
 threshold of 0.84. If a single record pair reaches both thresholds, then we call
 it a link! This pair of records will end up in `potential_matches.csv` when the
 script completes.
 
-It's very likely that the names in dataset A and dataset B are not consistently
-formatted. This is where the `column_mappings` section comes in. It tells hlink
-to perform some data cleaning in the preprocessing step before matching occurs.
-The column mappings in the config file strip whitespace from the names and lowercase
-them to remove discrepancies in formatting between the two datasets.
+In the real world, it's very likely that the names in dataset A and dataset B
+are not consistently formatted. This is where the `column_mappings` section
+comes in. It tells hlink to perform some data cleaning in the preprocessing step
+before matching occurs. The column mappings in the tutorial config file strip
+whitespace from the names and lowercase them to remove discrepancies in formatting
+between the two datasets.
 
 Now that the config file is written, we can run hlink to generate some links. See
 the next section for a description of the tutorial script that runs hlink.
 
 ## The Tutorial Script
 
-The `tutorial.py` Python script contains code to load in the config file and run
-hlink to generate potential links between the two datasets. It creates a `LinkRun`,
-which is the main way to communicate with the hlink library. After analyzing the
+The tutorial.py Python script contains code to load in the config file and run
+hlink to generate potential matches between the two datasets. It creates a `LinkRun`,
+which is the main way to control the hlink library. After analyzing the
 config file for errors, it runs two link tasks: preprocessing and matching.
 
 The preprocessing task reads the data from the datasets in and does the data
@@ -84,16 +98,25 @@ cleaning and column mapping that we've asked it to do for us in the config file.
 
 The matching task does the real linking work, finding links between the two datasets.
 It stores its results in a `potential_matches` spark table. The script saves this
-table to the `potential_matches.csv` file.
+table to the `potential_matches.csv` file and prints it to the screen.
 
 ## Getting and Interpreting Results
 
 After running the tutorial script, we have a `potential_matches.csv` file that
 contains data on potential links that hlink identified between the two datasets.
-Each record in this dataset identifies a potential link. The id\_a and id\_b
+Each record in this dataset identifies a potential link. The ID\_a and ID\_b
 columns identify the records in dataset A and dataset B that have been linked.
 There are also some more fields that are useful for reviewing the links and confirming
 that they look reasonable. Some links may be more reasonable than others!
-Our linking strategy is deterministic and relatively simple, so it may catch
-more or less links than another strategy.
 
+## Things to Try
+
+- After running the tutorial script once, run it again. This time it should print
+statements like `Preexisting table: raw_df_a`. If hlink finds that a Spark table
+already exists when it goes to compute it, it will use the pre-existing table
+instead of recomputing it. To prevent this from happening, try passing the
+`--clean` argument to tutorial.py. This will tell the script to drop all of the
+pre-existing tables before it runs the linking job.
+
+- Try increasing or decreasing the Jaro-Winkler thresholds in the config file.
+How does this affect the matches that are generated?

--- a/examples/tutorial/data/A.csv
+++ b/examples/tutorial/data/A.csv
@@ -1,0 +1,14 @@
+ID,NAMELAST,NAMEFRST,AGE,SEX
+0,Baggins,Bilbo,111,0
+1,Bagins,Frodo,33,0
+2,de Vil,Cruela,53,1
+3,Lovelace,Ada,24,1
+4,Knight,Shovel,37,0
+5,Alighieri,Dante,13,0
+6,Achebe,Chinua,62,0
+7,Craft,Laura,22,1
+8,Saron,Yogg,,
+9,Neutron,Jimmy,12,0
+10,,Wallace,37,0
+11,,Gromit,4,0
+12,Hopper,Grace,73,1

--- a/examples/tutorial/data/B.csv
+++ b/examples/tutorial/data/B.csv
@@ -1,0 +1,10 @@
+ID,NAMELAST,NAMEFRST,AGE,SEX
+0,Lovelace,Ada,33,1
+1,Knight,Specter,35,0
+2,Alighere,Durante,25,0
+3,Knight,Shield,47,1
+4,Achebe,Chinua,73,0
+4,Deville,Cruella,62,1
+5,Croft,Lara,32,1
+6,Sackville-Baggins,Lobelia,60,1
+7,Saron,Yogg,,

--- a/examples/tutorial/tutorial.py
+++ b/examples/tutorial/tutorial.py
@@ -1,11 +1,26 @@
+import argparse
+
 from hlink.linking.link_run import LinkRun
 from hlink.spark.factory import SparkFactory
 from hlink.configs.load_config import load_conf_file
 from hlink.scripts.lib.io import write_table_to_csv
 from hlink.scripts.lib.conf_validations import analyze_conf
+from hlink.scripts.lib.table_ops import drop_all_tables
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--clean", action="store_true", help="drop existing Spark tables on startup"
+    )
+
+    return parser.parse_args()
 
 
 def main():
+    args = parse_args()
+
     # First let's create a LinkRun object. This will be the main way that we
     # interact with hlink. To create a LinkRun, we need to read in our config
     # file and set up spark.
@@ -17,6 +32,10 @@ def main():
 
     print("=== Creating the LinkRun")
     link_run = LinkRun(spark, config)
+
+    if args.clean:
+        print("=== Dropping all pre-existing Spark tables")
+        drop_all_tables(link_run)
 
     # Now we've got the LinkRun created. Let's analyze our config file to look
     # for errors that could cause hlink to fail.

--- a/examples/tutorial/tutorial.py
+++ b/examples/tutorial/tutorial.py
@@ -42,6 +42,9 @@ def main():
     print("=== Saving potential matches to potential_matches.csv")
     write_table_to_csv(link_run.spark, "potential_matches", "potential_matches.csv")
 
+    print("=== Potential matches")
+    link_run.get_table("potential_matches").df().show()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/tutorial/tutorial.py
+++ b/examples/tutorial/tutorial.py
@@ -9,7 +9,17 @@ from hlink.scripts.lib.table_ops import drop_all_tables
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="""
+        This script links two very small example datasets that live in the data
+        subdirectory. It reads in the tutorial_config.toml configuration file
+        and runs hlink's preprocessing and matching steps to find some potential
+        matches between the two datasets.
+
+        For a detailed walkthrough of the tutorial, please see the README.md
+        file in the same directory as this script.
+        """
+    )
 
     parser.add_argument(
         "--clean", action="store_true", help="drop existing Spark tables on startup"

--- a/examples/tutorial/tutorial_config.toml
+++ b/examples/tutorial/tutorial_config.toml
@@ -1,4 +1,4 @@
-id_column = "id"
+id_column = "ID"
 
 [datasource_a]
 alias = "a"


### PR DESCRIPTION
Closes #62.

This pull request adds some example data for the tutorial script to run on and improves the tutorial setup. The tutorial can now be run with

```
$ cd examples/tutorial
$ python tutorial.py
```

It prints some information as it's running and creates a potential_matches.csv file with possible matches between the example datasets A.csv and B.csv.