### PR TITLE
Log user input in the main loop

### DIFF
--- a/hlink/scripts/main_loop.py
+++ b/hlink/scripts/main_loop.py
@@ -71,7 +71,9 @@ class Main(Cmd):
     def reload_auto_complete_cache(self):
         self.table_names = [t.name for t in self.spark.catalog.listTables()]
 
-    def precmd(self, line):
+    def precmd(self, line: str) -> str:
+        if line.strip() != "":
+            logging.info(f"[User Input] {line}")
         return line
 
     # These are meant to be flags / switches, not long options with arguments  following them


### PR DESCRIPTION
Closes #57.

This is a small PR that updates the main loop to log user commands when they are input. This makes use of the `precmd` hook, which is called after input is received and before it is parsed and commands executed. To avoid flooding the logs with unhelpful information, I filtered out lines that are only whitespace so that they are not logged.

After considering a few different formats for logging user input, I settled on a format like `[User Input] run_all_steps preprocessing matching`, which I find fairly easy to read and also easily distinguishable from other log lines.