### PR TITLE
Use a single leading underscore to indicate private methods and functions

### DIFF
--- a/hlink/linking/core/comparison.py
+++ b/hlink/linking/core/comparison.py
@@ -9,25 +9,25 @@ import hlink.linking.core.comparison_feature as comparison_feature_core
 def get_comparison_leaves(comp):
     comp_leaves = []
 
-    def __get_comp_leaf(comp, comp_leaves):
+    def _get_comp_leaf(comp, comp_leaves):
 
         if "comp_a" in comp:
-            __get_comp_leaf(comp["comp_a"], comp_leaves)
-            __get_comp_leaf(comp["comp_b"], comp_leaves)
+            _get_comp_leaf(comp["comp_a"], comp_leaves)
+            _get_comp_leaf(comp["comp_b"], comp_leaves)
 
         else:
             comp_leaves.append(comp)
 
     if "comp_a" in comp:
-        __get_comp_leaf(comp["comp_a"], comp_leaves)
-        __get_comp_leaf(comp["comp_b"], comp_leaves)
+        _get_comp_leaf(comp["comp_a"], comp_leaves)
+        _get_comp_leaf(comp["comp_b"], comp_leaves)
 
     elif "secondary" in comp:
-        __get_comp_leaf(comp["threshold_a"], comp_leaves)
-        __get_comp_leaf(comp["threshold_b"], comp_leaves)
+        _get_comp_leaf(comp["threshold_a"], comp_leaves)
+        _get_comp_leaf(comp["threshold_b"], comp_leaves)
 
     else:
-        __get_comp_leaf(comp, comp_leaves)
+        _get_comp_leaf(comp, comp_leaves)
 
     return comp_leaves
 

--- a/hlink/linking/core/dist_table.py
+++ b/hlink/linking/core/dist_table.py
@@ -48,13 +48,13 @@ def register_dist_tables_and_create_sql(link_task, dist_features):
                 )
                 tables_loaded.append(st)
         if feature["key_count"] == 1:
-            join_clause = __key_count_1(
+            join_clause = _key_count_1(
                 dt, feature["column_name"], feature["loc_a"], feature["loc_b"]
             )
             if join_clause not in join_clauses:
                 join_clauses.append(join_clause)
         elif feature["key_count"] == 2:
-            join_clause = __key_count_2(
+            join_clause = _key_count_2(
                 dt,
                 feature["source_column_a"],
                 feature["source_column_b"],
@@ -68,7 +68,7 @@ def register_dist_tables_and_create_sql(link_task, dist_features):
                 join_clauses.append(join_clause)
         if st:
             if feature["secondary_key_count"] == 1:
-                join_clause = __key_count_1(
+                join_clause = _key_count_1(
                     st,
                     feature["secondary_source_column"],
                     feature["secondary_loc_a"],
@@ -92,7 +92,7 @@ def register_dist_tables_and_create_sql(link_task, dist_features):
     return join_clauses, tables_loaded
 
 
-def __key_count_1(table, column, loc_a, loc_b):
+def _key_count_1(table, column, loc_a, loc_b):
     join_clause = (
         f"LEFT JOIN {table} "
         f"ON a.{column} = {table}.{loc_a} "
@@ -101,7 +101,7 @@ def __key_count_1(table, column, loc_a, loc_b):
     return join_clause
 
 
-def __key_count_2(table, column_a, column_b, loc_a_0, loc_a_1, loc_b_0, loc_b_1):
+def _key_count_2(table, column_a, column_b, loc_a_0, loc_a_1, loc_b_0, loc_b_1):
     join_clause = (
         f"LEFT JOIN {table} "
         f"ON a.{column_a} = {table}.{loc_a_0} "

--- a/hlink/linking/core/substitutions.py
+++ b/hlink/linking/core/substitutions.py
@@ -15,11 +15,11 @@ def generate_substitutions(spark, df_selected, substitution_columns):
                 "regex_word_replace" in substitution
                 and substitution["regex_word_replace"]
             ):
-                df_selected = __apply_regex_substitution(
+                df_selected = _apply_regex_substitution(
                     df_selected, column_name, substitution, spark.sparkContext
                 )
             elif "substitution_file" in substitution:
-                df_selected = __apply_substitution(
+                df_selected = _apply_substitution(
                     df_selected, column_name, substitution, spark.sparkContext
                 )
             else:
@@ -29,7 +29,7 @@ def generate_substitutions(spark, df_selected, substitution_columns):
     return df_selected
 
 
-def __load_substitutions(file_name):
+def _load_substitutions(file_name):
     """Reads in the substitution file and returns a 2-tuple representing it.
 
     Parameters
@@ -51,13 +51,13 @@ def __load_substitutions(file_name):
     return (sub_froms, sub_tos)
 
 
-def __apply_substitution(df, column_name, substitution, sc):
+def _apply_substitution(df, column_name, substitution, sc):
     """Returns a new df with the values in the column column_name replaced using substitutions defined in substitution_file."""
     substitution_file = substitution["substitution_file"]
     join_value = substitution["join_value"]
     join_column = substitution["join_column"]
     join_column_alias = join_column + "_sub"
-    sub_froms, sub_tos = __load_substitutions(substitution_file)
+    sub_froms, sub_tos = _load_substitutions(substitution_file)
     subs = list(zip(sub_froms, sub_tos))
     Sub = namedtuple("Sub", ["sub_from", "sub_to"])
     sub_df = (
@@ -81,11 +81,11 @@ def __apply_substitution(df, column_name, substitution, sc):
     return df_sub.select(df_sub_selects)
 
 
-def __apply_regex_substitution(df, column_name, substitution, sc):
+def _apply_regex_substitution(df, column_name, substitution, sc):
     """Returns a new df with the values in the column column_name replaced using substitutions defined in substitution_file."""
 
     substitution_file = substitution["substitution_file"]
-    sub_froms, sub_tos = __load_substitutions(substitution_file)
+    sub_froms, sub_tos = _load_substitutions(substitution_file)
     subs = dict(zip(sub_froms, sub_tos))
     col = column_name
     df.checkpoint()

--- a/hlink/linking/training/link_step_create_comparison_features.py
+++ b/hlink/linking/training/link_step_create_comparison_features.py
@@ -24,9 +24,9 @@ class LinkStepCreateComparisonFeatures(LinkStep):
 
     def _run(self):
         self.task.spark.sql("set spark.sql.shuffle.partitions=200")
-        self.__create_training_features()
+        self._create_training_features()
 
-    def __create_training_features(self):
+    def _create_training_features(self):
         training_conf = str(self.task.training_conf)
         table_prefix = self.task.table_prefix
         config = self.task.link_run.config

--- a/hlink/spark/session.py
+++ b/hlink/spark/session.py
@@ -92,10 +92,10 @@ class SparkConnection(object):
             session.sql(f"CREATE DATABASE IF NOT EXISTS {self.db_name}")
         session.catalog.setCurrentDatabase(self.db_name)
         session.sparkContext.setCheckpointDir(str(self.tmp_dir))
-        self.__register_udfs(session)
+        self._register_udfs(session)
         return session
 
-    def __register_udfs(self, session):
+    def _register_udfs(self, session):
         session.udf.registerJavaFunction("jw", "com.isrdi.udfs.JWCompare", DoubleType())
         session.udf.registerJavaFunction(
             "jw_max", "com.isrdi.udfs.MaxJWCompare", DoubleType()


### PR DESCRIPTION
Closes #36.

This finishes up a transition that we have been working on for some time. We have been moving from indicating that methods and functions are private with double leading underscores, like `__create_features()`, to a single leading underscore, like `_create_features()`. This avoids mangling the method name in classes and is the industry standard as far as I am aware.

Double leading underscores can be used in classes if we need them for inheritance, but we have not so far.