### PR TITLE
Adjust dependency version specification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4
+FROM python:3.10
 
 RUN apt-get update && apt-get install openjdk-11-jdk -y
 

--- a/setup.py
+++ b/setup.py
@@ -33,24 +33,24 @@ for package in packages_with_templates:
 package_data["hlink.linking"].append("table_definitions.csv")
 
 install_requires = [
-    "colorama==0.4.4",
-    "ipython==8.3.0",
-    "Jinja2==3.1.2",
-    "numpy==1.22.3",
-    "pandas==1.4.2",
-    "pyspark==3.3.0",
-    "scikit-learn==1.1.0",
-    "toml==0.10.2",
+    "colorama~=0.4.0",
+    "ipython~=8.3.0",
+    "Jinja2~=3.1.0",
+    "numpy~=1.22.0",
+    "pandas~=1.4.0",
+    "pyspark~=3.3.0",
+    "scikit-learn~=1.1.0",
+    "toml~=0.10.0",
 ]
 
 dev_requires = [
-    "pre-commit",
-    "black==22.3.0",
-    "flake8==4.0.1",
-    "sphinx",
-    "recommonmark",
-    "pytest==7.1.2",
-    "twine",
+    "pytest~=7.1.0",
+    "black~=22.0",
+    "flake8~=5.0",
+    "pre-commit~=2.0",
+    "twine~=4.0",
+    "sphinx==5.1.1",
+    "recommonmark==0.7.1",
 ]
 
 setup(


### PR DESCRIPTION
Closes #58 by loosening and adjusting dependency specifications.
Closes #61 by upgrading Spark from 3.3.0 to 3.3.1.
Closes #23 by strictly pinning the version of Sphinx in the development dependencies.

This pull request adjusts how we specify dependency versions in setup.py. Instead of pinning to an exact version for production dependencies, we now specify a major and minor version and allow the patch version to vary. So dependencies may be silently upgraded from version 1.1.0 -> 1.1.3, for example. Updates to minor or major versions will still require a manual update. This uses the `~=` "compatible version" syntax for Python packaging.

The development dependencies are pinned on a more case-by-case basis. We want to keep Sphinx pinned to a particular version because the version is output in the documentation, so using different versions can cause the documentation to update unexpectedly. black and flake8 can vary more widely. They are both pretty stable, and I don't think we'll run into many issues with the current version specifications. Similarly for twine and pre-commit.

This also updates the Dockerfile, specifying the image as `python:3.10` instead of `python:3.10.4`. This pulls in the latest version of Python 3.10 instead of 3.10.4. The latest version at the moment is 3.10.8.