### PR TITLE
Add type hints for several central classes and functions

### DIFF
--- a/hlink/configs/load_config.py
+++ b/hlink/configs/load_config.py
@@ -4,13 +4,14 @@
 #   https://github.com/ipums/hlink
 
 from pathlib import Path
+from typing import Any
 import json
 import toml
 
 from hlink.errors import UsageError
 
 
-def load_conf_file(conf_name):
+def load_conf_file(conf_name: str) -> dict[str, Any]:
     """Flexibly load a config file.
 
     Given a path `conf_name`, look for a file at that path. If that file
@@ -24,7 +25,7 @@ def load_conf_file(conf_name):
     config dictionary.
 
     Args:
-        conf_name (str): the file to look for
+        conf_name: the file to look for
 
     Returns:
         dict: the contents of the config file

--- a/hlink/configs/load_config.py
+++ b/hlink/configs/load_config.py
@@ -28,7 +28,7 @@ def load_conf_file(conf_name: str) -> dict[str, Any]:
         conf_name: the file to look for
 
     Returns:
-        dict: the contents of the config file
+        the contents of the config file
 
     Raises:
         FileNotFoundError: if none of the three checked files exist

--- a/hlink/linking/link_step.py
+++ b/hlink/linking/link_step.py
@@ -2,7 +2,6 @@
 # For copyright and licensing information, see the NOTICE and LICENSE files
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
-from typing import List
 
 
 class LinkStep:
@@ -11,10 +10,10 @@ class LinkStep:
         task,
         desc: str,
         *,
-        input_table_names: List[str] = [],
-        output_table_names: List[str] = [],
-        input_model_names: List[str] = [],
-        output_model_names: List[str] = [],
+        input_table_names: list[str] = [],
+        output_table_names: list[str] = [],
+        input_model_names: list[str] = [],
+        output_model_names: list[str] = [],
     ):
         self.task = task
         self.desc = desc
@@ -23,12 +22,12 @@ class LinkStep:
         self.input_model_names = input_model_names
         self.output_model_names = output_model_names
 
-    def find_missing_input_table_names(self):
+    def find_missing_input_table_names(self) -> list[str]:
         tables = map(self.task.link_run.get_table, self.input_table_names)
         missing_tables = filter((lambda table: not table.exists()), tables)
         return [table.name for table in missing_tables]
 
-    def run(self):
+    def run(self) -> None:
         missing_table_names = self.find_missing_input_table_names()
         if len(missing_table_names) > 0:
             missing_names_str = ", ".join(missing_table_names)
@@ -38,7 +37,7 @@ class LinkStep:
 
         self._run()
 
-    def _run(self):
+    def _run(self) -> None:
         """Run the link step.
 
         This abstract method must be implemented by concrete subclasses. It is
@@ -46,5 +45,5 @@ class LinkStep:
         """
         raise NotImplementedError()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.desc

--- a/hlink/linking/table.py
+++ b/hlink/linking/table.py
@@ -2,14 +2,15 @@
 # For copyright and licensing information, see the NOTICE and LICENSE files
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
+import pyspark
 
 
 class Table:
-    """Represents a spark table which may or may not currently exist.
+    """Represents a Spark table which may or may not currently exist.
 
-    It's possible to pass table names that aren't valid spark table names to
+    It's possible to pass table names that aren't valid Spark table names to
     this class (for example, "@@@"). In this case, this class does not throw
-    errors; it just treats the tables like any other spark tables that don't
+    errors; it just treats the tables like any other Spark tables that don't
     exist.
     """
 
@@ -23,13 +24,13 @@ class Table:
         self.hide = hide
 
     def exists(self) -> bool:
-        """Check whether the table currently exists in spark."""
+        """Check whether the table currently exists in Spark."""
         return self._name_lower in [
             table.name for table in self.spark.catalog.listTables()
         ]
 
-    def drop(self):
-        """Drop the table if it `exists()`.
+    def drop(self) -> None:
+        """Drop the table if it exists.
 
         If the table doesn't exist, then don't do anything.
         """
@@ -39,15 +40,15 @@ class Table:
             not self.exists()
         ), f"table '{self.name}' has been dropped but still exists"
 
-    def df(self):
+    def df(self) -> pyspark.sql.dataframe.DataFrame | None:
         """Get the DataFrame of the table from spark.
 
         Returns:
-            Option[DataFrame]: the DataFrame of the table, or None if the table doesn't exist
+            the Spark DataFrame of the table, or None if the table doesn't exist
         """
         if self.exists():
             return self.spark.table(self._name_lower)
         return None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Table '{self.name}' <- {self.desc}"

--- a/hlink/linking/util.py
+++ b/hlink/linking/util.py
@@ -5,7 +5,7 @@ MIN_PARTITIONS = 200
 MAX_PARTITIONS = 10000
 
 
-def spark_shuffle_partitions_heuristic(dataset_size):
+def spark_shuffle_partitions_heuristic(dataset_size: int) -> int:
     """Calculate how many partitions to request from Spark based on dataset size.
 
     This is a heuristic / approximation of how many partitions should be requested


### PR DESCRIPTION
This PR closes #69.

It adds type hints for the following classes and functions.
- `Table`
- `spark_shuffle_partitions_heuristic()`
-  `LinkRun`
-  `LinkTask`
-  `LinkStep`
-  `load_conf_file()`

Most of the type hints are relatively straightforward. However, for `LinkTask.run_register_python()`, the `func` and `args` arguments have tricky types. `run_register_python` takes in these arguments and calls `func(*args)`. So `args` must be an iterable so that we can unpack it into an argument list with `*`. But there are no more restrictions on the types of arguments, so `args` has type `Iterable[Any]`. It defaults to the empty list. `func` is a `Callable` that returns a Spark DataFrame. Its arguments are exactly the contents of `args`. But specifying the type and number of arguments is impossible without knowing more about `args`. I ran `mypy` on my first attempt of `Callable[Any, pyspark.sql.dataframe.DataFrame]`. It errored out but recommended the special syntax of `Callable[..., pyspark.sql.dataframe.DataFrame]`, which makes use of Python's ellipsis object `...`. So this is the type I used. It looks pretty nice to me.