### PR TITLE
Some refactoring and cleanup

### DIFF
--- a/hlink/errors.py
+++ b/hlink/errors.py
@@ -7,16 +7,10 @@
 class SparkError(Exception):
     """Catch any exceptions from Spark"""
 
-    pass
-
 
 class UsageError(Exception):
     """Incorrectly specified options"""
 
-    pass
-
 
 class DataError(Exception):
     """There is an issue in the source data that will cause a problem."""
-
-    pass

--- a/hlink/linking/core/comparison_feature.py
+++ b/hlink/linking/core/comparison_feature.py
@@ -255,7 +255,7 @@ def generate_comparison_feature(feature, id_col, include_as=False):
 
     elif comp_type == "all_equals":
         cols = feature["column_names"]
-        all_equals = " AND ".join([f"a.{col} = b.{col}" for col in cols])
+        all_equals = " AND ".join(f"a.{col} = b.{col}" for col in cols)
         expr = f"{all_equals}"
 
     elif comp_type == "not_zero_and_not_equals":

--- a/hlink/linking/core/comparison_feature.py
+++ b/hlink/linking/core/comparison_feature.py
@@ -540,7 +540,7 @@ def generate_comparison_feature(feature, id_col, include_as=False):
         expr = f"CASE WHEN {datasource}.{addl_var} {check_val_expr} then {expr} else {else_val} END"
 
     if include_as:
-        full_expr = f"({expr})" + f" as {feature['alias']}"
+        full_expr = f"({expr}) as {feature['alias']}"
     else:
         full_expr = expr
 

--- a/hlink/linking/core/transforms.py
+++ b/hlink/linking/core/transforms.py
@@ -295,7 +295,7 @@ def generate_transforms(
             return df_selected
 
         else:
-            raise ValueError("Invalid transform type for {}".format(str(transform)))
+            raise ValueError(f"Invalid transform type for {transform}")
 
     for feature_selection in not_skipped_feature_selections:
         df_selected = parse_feature_selections(df_selected, feature_selection, is_a)
@@ -513,4 +513,4 @@ def apply_transform(column_select, transform, is_a):
     elif transform_type == "get_floor":
         return floor(column_select).cast("int")
     else:
-        raise ValueError("Invalid transform type for {}".format(str(transform)))
+        raise ValueError(f"Invalid transform type for {transform}")

--- a/hlink/linking/core/transforms.py
+++ b/hlink/linking/core/transforms.py
@@ -464,13 +464,13 @@ def apply_transform(column_select, transform, is_a):
                 "DEPRECATION WARNING: The 'mapping' transform no longer takes the 'values' parameter with a list of mappings in dictionaries; instead each mapping should be its own transform. Please change your config for future releases."
             )
             for mapping in transform["values"]:
-                from_regexp = "|".join("^" + str(f) + "$" for f in mapping["from"])
+                from_regexp = "|".join(f"^{from_val}$" for from_val in mapping["from"])
                 mapped_column = regexp_replace(
                     mapped_column, from_regexp, str(mapping["to"])
                 )
         else:
             for key, value in transform["mappings"].items():
-                from_regexp = "^" + str(key) + "$"
+                from_regexp = f"^{key}$"
                 mapped_column = regexp_replace(mapped_column, from_regexp, str(value))
         if transform.get("output_type", False) == "int":
             mapped_column = mapped_column.cast(LongType())

--- a/hlink/linking/core/transforms.py
+++ b/hlink/linking/core/transforms.py
@@ -464,7 +464,7 @@ def apply_transform(column_select, transform, is_a):
                 "DEPRECATION WARNING: The 'mapping' transform no longer takes the 'values' parameter with a list of mappings in dictionaries; instead each mapping should be its own transform. Please change your config for future releases."
             )
             for mapping in transform["values"]:
-                from_regexp = "|".join(["^" + str(f) + "$" for f in mapping["from"]])
+                from_regexp = "|".join("^" + str(f) + "$" for f in mapping["from"])
                 mapped_column = regexp_replace(
                     mapped_column, from_regexp, str(mapping["to"])
                 )

--- a/hlink/linking/link_task.py
+++ b/hlink/linking/link_task.py
@@ -13,7 +13,7 @@ from hlink.errors import SparkError
 from hlink.linking.link_step import LinkStep
 
 
-class LinkTask(object):
+class LinkTask:
     """Base class for link tasks.
 
     A link task consists of one or more `LinkStep`s and belongs to one `LinkRun`.

--- a/hlink/linking/link_task.py
+++ b/hlink/linking/link_task.py
@@ -85,7 +85,7 @@ class LinkTask:
 
         if step_num < 0 or step_num >= len(steps):
             steps_string = "\n\t".join(
-                [f"step {i}: {steps[i].desc}" for i in range(len(steps))]
+                [f"step {i}: {step.desc}" for (i, step) in enumerate(steps)]
             )
             print(
                 f"Error! Couldn't find step {step_num}. Valid steps are: \n\t{steps_string}"

--- a/hlink/linking/matching/link_step_score.py
+++ b/hlink/linking/matching/link_step_score.py
@@ -111,7 +111,7 @@ class LinkStepScore(LinkStep):
 
     def _save_feature_importances(self, spark, score_tmp):
         config = self.task.link_run.config
-        if not (config[f"{self.task.training_conf}"].get("feature_importances", False)):
+        if not config[f"{self.task.training_conf}"].get("feature_importances", False):
             return
         cols = (
             score_tmp.select("*").schema["features_vector"].metadata["ml_attr"]["attrs"]

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -110,7 +110,7 @@ class LinkStepTrainTestModels(LinkStep):
                 )
 
                 thresholds_plus_1 = np.append(thresholds_raw, [np.nan])
-                param_text = np.full(precision.shape, model_type + "_" + str(params))
+                param_text = np.full(precision.shape, f"{model_type}_{params}")
 
                 pr_auc = auc(recall, precision)
                 print(f"Area under PR curve: {pr_auc}")
@@ -128,7 +128,7 @@ class LinkStepTrainTestModels(LinkStep):
                         "overwrite"
                     ).saveAsTable(
                         f"{self.task.table_prefix}precision_recall_curve_"
-                        + re.sub("[^A-Za-z0-9]", "_", model_type + str(params))
+                        + re.sub("[^A-Za-z0-9]", "_", f"{model_type}{params}")
                     )
 
                     first = False

--- a/hlink/linking/reporting/link_step_export_crosswalk.py
+++ b/hlink/linking/reporting/link_step_export_crosswalk.py
@@ -43,9 +43,9 @@ class LinkStepExportCrosswalk(LinkStep):
         raw_cols = ["histid", "serialp", "pernum", "age", "sex", "statefip", "bpl"]
 
         raw_cols_sql = "select "
-        raw_cols_sql += ", ".join([f"raw_a.{col} as {col}_a" for col in raw_cols])
+        raw_cols_sql += ", ".join(f"raw_a.{col} as {col}_a" for col in raw_cols)
         raw_cols_sql += ", "
-        raw_cols_sql += ", ".join([f"raw_b.{col} as {col}_b" for col in raw_cols])
+        raw_cols_sql += ", ".join(f"raw_b.{col} as {col}_b" for col in raw_cols)
         raw_cols_sql += "from all_predicted_matches left join raw_df_a raw_a on histid_a left join raw_df_b raw_b on histid_b"
 
         joined_predictions_with_demog = self.task.spark.sql(raw_cols_sql)

--- a/hlink/linking/reporting/link_step_report_representivity.py
+++ b/hlink/linking/reporting/link_step_report_representivity.py
@@ -43,8 +43,8 @@ class LinkStepReportRepresentivity(LinkStep):
             "durmarr",
             "sei",
         }
-        raw_a_cols_present = set([x.lower() for x in spark.table("raw_df_a").columns])
-        raw_b_cols_present = set([x.lower() for x in spark.table("raw_df_b").columns])
+        raw_a_cols_present = {x.lower() for x in spark.table("raw_df_a").columns}
+        raw_b_cols_present = {x.lower() for x in spark.table("raw_df_b").columns}
         raw_cols = list(raw_cols_wishlist & raw_a_cols_present & raw_b_cols_present)
 
         prepped_cols_wishlist = {
@@ -58,12 +58,8 @@ class LinkStepReportRepresentivity(LinkStep):
             "namelast_clean",
             "statefip",
         }
-        pdfa_cols_present = set(
-            [x.lower() for x in spark.table("prepped_df_a").columns]
-        )
-        pdfb_cols_present = set(
-            [x.lower() for x in spark.table("prepped_df_b").columns]
-        )
+        pdfa_cols_present = {x.lower() for x in spark.table("prepped_df_a").columns}
+        pdfb_cols_present = {x.lower() for x in spark.table("prepped_df_b").columns}
         prepped_cols = list(
             prepped_cols_wishlist & pdfa_cols_present & pdfb_cols_present
         )

--- a/hlink/linking/training/link_step_train_and_save_model.py
+++ b/hlink/linking/training/link_step_train_and_save_model.py
@@ -27,7 +27,7 @@ class LinkStepTrainAndSaveModel(LinkStep):
         table_prefix = self.task.table_prefix
         config = self.task.link_run.config
 
-        if not (config[training_conf].get("score_with_model", False)):
+        if not config[training_conf].get("score_with_model", False):
             raise ValueError(
                 f"'score_with_model' not included or set to true in '{training_conf}' section of config!  Initiation of a model and scoring not completed!"
             )

--- a/hlink/scripts/lib/experimental/reporting.py
+++ b/hlink/scripts/lib/experimental/reporting.py
@@ -67,7 +67,7 @@ def export_csv(all_matches_with_selections, output_path):
     output_tmp = output_path + ".tmp"
     all_matches_with_selections.write.csv(output_tmp, header=False)
     header = (
-        '"' + '","'.join([col.name for col in all_matches_with_selections.schema]) + '"'
+        '"' + '","'.join(col.name for col in all_matches_with_selections.schema) + '"'
     )
 
     commands = [

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -199,7 +199,7 @@ def _get_spark(run_conf, args):
 
 
 def _read_history_file(history_file):
-    if not (os.path.exists(history_file)):
+    if not os.path.exists(history_file):
         with open(history_file, "a"):
             os.utime(history_file, (1330712280, 1330712292))
     readline.read_history_file(history_file)

--- a/hlink/scripts/main_loop.py
+++ b/hlink/scripts/main_loop.py
@@ -14,10 +14,10 @@ from hlink.linking.link_run import link_task_choices
 
 import hlink.scripts.lib.experimental.tfam as x_tfam
 import hlink.scripts.lib.experimental.reporting as x_reporting
-import hlink.scripts.lib.table_ops as table_ops
-import hlink.scripts.lib.io as io
-import hlink.scripts.lib.linking_ops as linking_ops
-import hlink.scripts.lib.conf_validations as conf_validations
+from hlink.scripts.lib import table_ops
+from hlink.scripts.lib import io
+from hlink.scripts.lib import linking_ops
+from hlink.scripts.lib import conf_validations
 
 
 def split_and_check_args(expected_count):
@@ -36,7 +36,7 @@ def split_and_check_args(expected_count):
         def wrapper(self, args):
             split_args = args.split()
             if self.check_arg_count(split_args, expected_count, f.__doc__):
-                return
+                return None
             return f(self, split_args)
 
         return wrapper
@@ -470,7 +470,7 @@ class Main(Cmd):
             return
 
         output_path, variables_string = split_args
-        variables = list([v.lower() for v in variables_string.split(",")])
+        variables = [v.lower() for v in variables_string.split(",")]
 
         if include_round:
             print("Including round numbers in exported data")

--- a/hlink/spark/session.py
+++ b/hlink/spark/session.py
@@ -18,7 +18,7 @@ from pyspark.sql.types import (
 )
 
 
-class SparkConnection(object):
+class SparkConnection:
     """Handles initialization of spark session and connection to local cluster."""
 
     def __init__(self, derby_dir, warehouse_dir, tmp_dir, python, db_name):

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -143,7 +143,7 @@ def test_step_2_param_grid(spark, main, training_conf, model_exploration, fake_s
     ]
 
     assert len(param_grid) == len(expected)
-    assert all([m in expected for m in param_grid])
+    assert all(m in expected for m in param_grid)
 
     main.do_drop_all("")
 
@@ -241,7 +241,7 @@ def test_step_1_OneHotEncoding(
         "features_vector",
     ]
     assert training_v.shape[0] == 9
-    assert all([c in training_v.columns for c in columns_expected])
+    assert all(c in training_v.columns for c in columns_expected)
     assert len(training_v["features_vector"][0]) == 5
 
 


### PR DESCRIPTION
This is a smaller PR that cleans up some lines and tries to simplify some statements and expressions.

I ran pylint on our code and some of these changes were suggested by pylint. Others are things that I've just noticed and wanted to fix. Here are some things I tried to do:

- Replace list comprehensions with generator expressions where it makes sense. This just means getting rid of the `[]` around the generator expression, which at least to me makes it easier to read.
- Use set comprehensions instead of constructing a set from a list comprehension.
- Simplify some string formatting with f-strings and avoid `str.format()`.
- Use `enumerate()` instead of `range(len(...))` where it makes sense.