### PR TITLE
Allow running tests with just `pytest`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,7 +23,7 @@ jobs:
       run: docker run $HLINK_TAG flake8 --count .
       
     - name: Test
-      run: docker run $HLINK_TAG pytest hlink/tests
+      run: docker run $HLINK_TAG pytest
     
     - name: Build sdist and wheel
       run: docker run $HLINK_TAG python -m build

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+pytest_plugins = (
+    "hlink.tests.plugins.datasources",
+    "hlink.tests.plugins.external_data_paths",
+)

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -19,9 +19,9 @@ To set up a copy of this project for development,
 
 ## Running Tests
 
-To run the project's test suite, run `pytest hlink/tests` in the root project directory. Running all of the tests
+To run the project's test suite, run `pytest` in the root project directory. Running all of the tests
 can take a while, depending on your computer's hardware and setup. To run a subset of tests that test some but not
-all of the core features, try `pytest hlink/tests -m quickcheck`. These tests should run much more quickly.
+all of the core features, try `pytest -m quickcheck`. These tests should run much more quickly.
 
 ## Building the Scala Jar
 

--- a/hlink/tests/conftest.py
+++ b/hlink/tests/conftest.py
@@ -23,12 +23,6 @@ import sys
 from types import SimpleNamespace
 
 
-pytest_plugins = (
-    "hlink.tests.plugins.datasources",
-    "hlink.tests.plugins.external_data_paths",
-)
-
-
 def load_table_from_csv(link_task, path, table_name):
     link_task.spark.read.csv(path, header=True, inferSchema=True).write.mode(
         "overwrite"


### PR DESCRIPTION
Closes #67.

This PR enables running the tests with the command `pytest` instead of `pytest hlink/tests`. This required creating a conftest.py file in the root directory and moving `pytest_plugins` from hlink/tests/conftest.py to the new conftest.py.

I updated our CI GitHub Action so that it invokes `pytest` instead of `pytest hlink/tests`, and I updated some developer documentation so that it recommends just using `pytest` as well. `pytest hlink/tests` still does work as it did before.