### PR TITLE
Don't reload modules for the reload command

### DIFF
--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -224,6 +224,7 @@ def _cli_loop(spark, args, run_conf):
         try:
             main.cmdloop()
             if main.lastcmd == "reload":
+                logging.info("Reloading config file")
                 run_conf = load_conf(args.conf, args.user)
             else:
                 break

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -5,7 +5,6 @@
 
 import argparse
 import getpass
-from importlib import reload
 import logging
 import os
 from pathlib import Path
@@ -225,29 +224,11 @@ def _cli_loop(spark, args, run_conf):
         try:
             main.cmdloop()
             if main.lastcmd == "reload":
-                _reload_modules()
-                # Reload modules twice in order to fix import problem
-                # with the _*.py files in the linking modules
-                _reload_modules()
                 run_conf = load_conf(args.conf, args.user)
             else:
                 break
         except Exception as err:
             report_and_log_error("", err)
-
-
-def _reload_modules():
-    no_reloads = []
-    mods_to_reload_raw = [name for name, mod in sys.modules.items()]
-    # We need to order the modules to reload the _*.py files in the
-    # linking modules before loading the __init__.py files.
-    mods_to_reload_ordered = sorted(mods_to_reload_raw)[::-1]
-    for name in mods_to_reload_ordered:
-        if name.startswith("hlink") and name not in no_reloads:
-            reload(sys.modules[name])
-
-    # Here we should reset the classes in link_run.link_task_choices with
-    # the newly reloaded classes.
 
 
 def _setup_logging(conf):

--- a/hlink/scripts/main_loop.py
+++ b/hlink/scripts/main_loop.py
@@ -139,7 +139,7 @@ class Main(Cmd):
 
     @split_and_check_args(0)
     def do_reload(self, split_args):
-        """Hot reload modules.
+        """Reload the config file.
         Usage: reload"""
         return "reload"
 


### PR DESCRIPTION
This removes the Python module reloading from the reload command, which was pretty hard to follow and not related to the main purpose of reloading the config file.