### PR TITLE
Fix categorical variable bug

### DIFF
--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -190,7 +190,9 @@ def _calc_categorical_features(
                 "categorical", False
             ):
                 categorical_pipeline_features.append(pipeline_feature["output_column"])
-
+    logging.info(f"Categorical Comparison features: {categorical_pipeline_features}")
+    logging.info(f"Categorical Pipeline features: {categorical_pipeline_features}")
+    
     return categorical_comparison_features, categorical_pipeline_features
 
 

--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -12,7 +12,7 @@ from pyspark.ml.feature import (
 )
 import hlink.linking.transformers.interaction_transformer
 import hlink.linking.transformers.float_cast_transformer
-
+import logging
 
 def generate_pipeline_stages(conf, ind_vars, tf, tconf):
     """Creates a Spark ML pipeline from the pipeline features.
@@ -178,12 +178,9 @@ def _calc_categorical_features(
     cols = set(cols_to_pass + ind_vars)
 
     # Check for categorical features in all comparison features
-    for x in comparison_features:
-        if x["alias"] in cols:
-            if "categorical" in x.keys():
-                categorical_comparison_features.append(x["alias"])
-        else:
-            continue
+    for comparison_feature in comparison_features:
+        if comparison_feature["alias"] in cols and comparison_feature.get("categorical", False):
+                categorical_comparison_features.append(comparison_feature["alias"])
 
     # Check for categorical features in the pipeline-generated features (if exist)
 


### PR DESCRIPTION
This PR is to fix the issue where non-categorical columns where added into the categorical_comparsion_features list.
The code change here fixes the issue by adding a check for categorical = "false" in pipeline.py .
Here the the check  `comparison_feature.get("categorical", False)`  returns the value  of the key "categorical" and returns "false" as default when the key is not found in the dict.

Trello card : https://trello.com/c/ytJOdsk3/1424-bug-hlink-comparisonfeatures-marked-as-categorical-false-are-still-treated-as-categorical

A logging statement has also been added as part of the PR to be able to see the lots of categorical comparison features and categorical pipeline features.