### PR TITLE
Pin the Docker image to Debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10-bullseye
 
 RUN apt-get update && apt-get install openjdk-11-jdk -y
 


### PR DESCRIPTION
With just python:3.10, we're getting an error because openjdk-11 isn't available. Currently python:3.10 points to python:3.10.12-bookworm. bookworm is a newer release of Debian, so my guess is that support for openjdk-11 has been dropped on it. We will need to deal with this by updating which openjdk we use eventually, but for now we can pin to python:3.10-bullseye to keep support for openjdk-11.