### PR TITLE
Drop the comment column in the desc command

### DIFF
--- a/hlink/scripts/lib/table_ops.py
+++ b/hlink/scripts/lib/table_ops.py
@@ -25,7 +25,8 @@ def show_table_row_count(spark, table_name):
 
 
 def show_table_columns(spark, table_name):
-    spark.sql(f"DESCRIBE {table_name}").show(1000, truncate=False)
+    # We don't make use of comments, so the comment column is full of nulls.
+    spark.sql(f"DESCRIBE {table_name}").drop("comment").show(1000, truncate=False)
 
 
 def show_column_summary(spark, table_name, col_name):


### PR DESCRIPTION
Fixes #85.

This column is automatically returned when running 'DESCRIBE table', but we don't really use it in hlink at the moment. So it's all nulls. This is a bug; we should just not show it to the user. The desc command gives you the names of the columns and their data types in Spark.