### PR TITLE
Make the CI Dockerfile more flexible and maintainable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,9 +18,9 @@ jobs:
 
     - name: Check dependency versions
       run: |
-        echo "Python version: $(python -V)"
+        docker run $HLINK_TAG echo "Python version: $(python -V)"
         echo "Java version:"
-        java -version
+        docker run $HLINK_TAG java -version
     
     - name: Check formatting with black
       run: docker run $HLINK_TAG black --check .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag $HLINK_TAG
-      
+
+    - name: Check dependency versions
+      run: |
+        echo -n "Running with Python version $(python -V)"
+        echo " and with Java version $(java -version)"
+    
     - name: Check formatting with black
       run: docker run $HLINK_TAG black --check .
       

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,8 +18,9 @@ jobs:
 
     - name: Check dependency versions
       run: |
-        echo -n "Running with Python version $(python -V)"
-        echo " and with Java version $(java -version)"
+        echo "Python version: $(python -V)"
+        echo "Java version:"
+        java -version
     
     - name: Check formatting with black
       run: docker run $HLINK_TAG black --check .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10-bullseye
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-bullseye
 
 RUN apt-get update && apt-get install openjdk-11-jdk -y
 
@@ -6,4 +7,5 @@ RUN mkdir /hlink
 WORKDIR /hlink
 
 COPY . .
+RUN python -m pip install --upgrade pip
 RUN pip install -e .[dev]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=3.10
 FROM python:${PYTHON_VERSION}
 
-RUN apt-get update && apt-get install default-jdk -y
+RUN apt-get update && apt-get install default-jre-headless -y
 
 RUN mkdir /hlink
 WORKDIR /hlink

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=3.10
-FROM python:${PYTHON_VERSION}-bullseye
+FROM python:${PYTHON_VERSION}
 
-RUN apt-get update && apt-get install openjdk-11-jdk -y
+RUN apt-get update && apt-get install default-jdk -y
 
 RUN mkdir /hlink
 WORKDIR /hlink

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Wellington, J., R. Harper, and K.J. Thompson. 2022. "hlink." https://github.com/
 
 ## Installation
 
-hlink runs on Python 3.10.
-Java 8 or [Java 11](https://openjdk.org/install/) is required for the PySpark integration. 
+hlink runs on Python 3.10 and requires Java 8 or greater for integration with PySpark.
 
 You can install the python package from pip:
 ```


### PR DESCRIPTION
Closes #91 and lays some initial infrastructure for #90.

This PR accomplishes two main tasks.

### Python Version Parametrization

With the `--build-arg PYTHON_VERSION=x` argument, we can now specify the version of Python to download in the Dockerfile. This will be useful for #90 when we want to parametrize the CI job to run it in parallel for several versions of Python. At the moment we are still stuck on Python 3.10, but soon we should hopefully be able to run on both 3.10 and 3.11 (and then 3.12 as well!).

### Java Version Clarifications

We don't need a particular version of Java to integrate with pyspark. We just need Java 8 or greater, per their documentation at https://spark.apache.org/docs/3.3.3/api/python/getting_started/install.html#dependencies. (And we also don't need the whole JDK, just a JRE.) So we've switched to installing `default-jre-headless` instead of OpenJDK 11 in the Dockerfile. This installs Java 17 on the current OS version, which is Debian bookworm. It lets us unpin the Dockerfile from the old OS version, Debian bullseye.