### PR TITLE
Deprecate the interaction_transformer module

### DIFF
--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -109,32 +109,33 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         pipeline_stages.append(encoder)
 
     if "pipeline_features" in conf:
-        for x in conf["pipeline_features"]:
-            if x["output_column"] in pipeline_input_cols:
-                if x["transformer_type"] == "bucketizer":
-                    splits = x["splits"]
-                    if x["input_column"] in col_names_dict.keys():
-                        input_col = col_names_dict[x["input_column"]]
+        for pipeline_feature in conf["pipeline_features"]:
+            if pipeline_feature["output_column"] in pipeline_input_cols:
+                if pipeline_feature["transformer_type"] == "bucketizer":
+                    splits = pipeline_feature["splits"]
+                    if pipeline_feature["input_column"] in col_names_dict.keys():
+                        input_col = col_names_dict[pipeline_feature["input_column"]]
                     else:
-                        input_col = x["input_column"]
+                        input_col = pipeline_feature["input_column"]
                     bucketizer = Bucketizer(
-                        splits=splits, inputCol=input_col, outputCol=x["output_column"]
+                        splits=splits,
+                        inputCol=input_col,
+                        outputCol=pipeline_feature["output_column"],
                     )
                     pipeline_stages.append(bucketizer)
 
-                elif x["transformer_type"] == "interaction":
+                elif pipeline_feature["transformer_type"] == "interaction":
                     input_cols = []
-                    for key in x["input_columns"]:
+                    for key in pipeline_feature["input_columns"]:
                         if key in col_names_dict.keys():
                             input_cols.append(col_names_dict[key])
                         else:
                             input_cols.append(key)
                     interaction = Interaction(
-                        inputCols=input_cols, outputCol=x["output_column"]
+                        inputCols=input_cols,
+                        outputCol=pipeline_feature["output_column"],
                     )
                     pipeline_stages.append(interaction)
-            else:
-                continue
 
     if len(categorical_pipeline_features) > 0:
         encoded_output_cols = [

--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -9,8 +9,8 @@ from pyspark.ml.feature import (
     OneHotEncoder,
     VectorAssembler,
     Bucketizer,
+    Interaction,
 )
-import hlink.linking.transformers.interaction_transformer
 import hlink.linking.transformers.float_cast_transformer
 import logging
 
@@ -129,10 +129,10 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
                             input_cols.append(col_names_dict[key])
                         else:
                             input_cols.append(key)
-                    interaction_transformer = hlink.linking.transformers.interaction_transformer.InteractionTransformer(
+                    interaction = Interaction(
                         inputCols=input_cols, outputCol=x["output_column"]
                     )
-                    pipeline_stages.append(interaction_transformer)
+                    pipeline_stages.append(interaction)
             else:
                 continue
 

--- a/hlink/linking/transformers/interaction_transformer.py
+++ b/hlink/linking/transformers/interaction_transformer.py
@@ -3,10 +3,20 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import warnings
 from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.param.shared import HasInputCols, HasOutputCol
 from pyspark import keyword_only
 from pyspark.ml.wrapper import JavaTransformer
+
+
+warnings.warn(
+    "interaction_transformer is deprecated and will be removed in the future. "
+    "This module provides the InteractionTransformer class, which is a backport of pyspark.ml.feature.Interaction. "
+    "Please use pyspark.ml.feature.Interaction instead.",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class InteractionTransformer(


### PR DESCRIPTION
Closes #80.

This was added as a backport of the `pyspark.ml.feature.Interaction` class while we were on Spark 2, but now we can use the official Spark version since we're on Spark 3. To prevent drift between our version and the Spark version, this module is now deprecated, and users should import and use `pyspark.ml.feature.Interaction` instead of `InteractionTransformer`. I've made this change in `hlink.linking.core.pipeline` and cleaned up the surrounding code a bit.