### PR TITLE
Fix a bug in Training step 3 for categorical features

### DIFF
--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -99,7 +99,6 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoder = OneHotEncoder(
             inputCols=categorical_comparison_features,
             outputCols=encoded_output_cols,
-            handleInvalid="keep",
             dropLast=False,
         )
         # feature_names = list((set(feature_names) - set(categorical_comparison_features)) | set(encoded_output_cols))
@@ -144,7 +143,6 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoder = OneHotEncoder(
             inputCols=categorical_pipeline_features,
             outputCols=encoded_output_cols,
-            handleInvalid="keep",
             dropLast=False,
         )
         # feature_names = list((set(feature_names) - set(categorical_pipeline_features)) | set(encoded_output_cols))

--- a/hlink/linking/table_definitions.csv
+++ b/hlink/linking/table_definitions.csv
@@ -18,6 +18,8 @@ training_data,Training: Raw training data as read from specified file,1
 hh_training_data,Household Training: Raw HH training data as read from specified file,1
 training_features,Training: Transformed data with features,1
 hh_training_features,Household Training: Transformed HH training data with features,1
+training_features_prepped,Training: Training data with features and imputed values and encoded categorical features,1
+hh_training_features_prepped,Household Training: HH training data with features and imputed values and encoded categorical features,1
 training_feature_importances,Training: Feature importances for the trained model,0
 model_eval_training_data,Model Exploration: Raw training data as read from specified file,1
 model_eval_training_vectorized,Model Exploration: Training data after applying comparison feature and pipeline transformations,1

--- a/hlink/linking/training/link_step_save_model_metadata.py
+++ b/hlink/linking/training/link_step_save_model_metadata.py
@@ -4,8 +4,6 @@
 #   https://github.com/ipums/hlink
 
 from hlink.linking.link_step import LinkStep
-import hlink.linking.core.pipeline as pipeline_core
-from pyspark.ml import Pipeline
 
 
 class LinkStepSaveModelMetadata(LinkStep):

--- a/hlink/linking/training/link_step_save_model_metadata.py
+++ b/hlink/linking/training/link_step_save_model_metadata.py
@@ -23,6 +23,7 @@ class LinkStepSaveModelMetadata(LinkStep):
         super().__init__(
             task,
             "save metadata about the model",
+            input_table_names=[f"{task.table_prefix}training_features_prepped"],
             output_table_names=[f"{task.table_prefix}training_feature_importances"],
             input_model_names=[f"{task.table_prefix}trained_model"],
         )
@@ -85,11 +86,7 @@ class LinkStepSaveModelMetadata(LinkStep):
             float(importance) for importance in feature_imp.toArray()
         ]
 
-        # Maybe find a way to hide this table earlier or get # of coefficients earlier rather than re-call
-        tf = self.task.spark.table(f"{table_prefix}training_features")
-
-        pre_pipeline = self.task.link_run.trained_models[f"{table_prefix}pre_pipeline"]
-        tf_prepped = pre_pipeline.transform(tf).toPandas()
+        tf_prepped = self.task.spark.table(f"{table_prefix}training_features_prepped")
 
         true_cols = []
         for col in column_names:

--- a/hlink/linking/training/link_step_train_and_save_model.py
+++ b/hlink/linking/training/link_step_train_and_save_model.py
@@ -18,7 +18,7 @@ class LinkStepTrainAndSaveModel(LinkStep):
             task,
             "train and save the model",
             input_table_names=[f"{task.table_prefix}training_features"],
-            output_table_names=[],
+            output_table_names=[f"{task.table_prefix}training_features_prepped"],
             output_model_names=[f"{task.table_prefix}trained_model"],
         )
 
@@ -59,6 +59,10 @@ class LinkStepTrainAndSaveModel(LinkStep):
         pre_pipeline = Pipeline(stages=pipeline_stages[:-1]).fit(tf)
         self.task.link_run.trained_models[f"{table_prefix}pre_pipeline"] = pre_pipeline
         tf_prepped = pre_pipeline.transform(tf)
+
+        tf_prepped.write.mode("overwrite").saveAsTable(
+            f"{table_prefix}training_features_prepped"
+        )
 
         classifier, post_transformer = classifier_core.choose_classifier(
             chosen_model_type, chosen_model_params, dep_var

--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -113,7 +113,6 @@ def test_all_steps(
 
     training.run_step(3)
     tf = spark.table("training_feature_importances").toPandas()
-    print(tf)
     for var in training_conf["training"]["independent_vars"]:
         assert not tf.loc[tf["feature_name"].str.startswith(f"{var}", na=False)].empty
     assert all(

--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -113,6 +113,7 @@ def test_all_steps(
 
     training.run_step(3)
     tf = spark.table("training_feature_importances").toPandas()
+    print(tf)
     for var in training_conf["training"]["independent_vars"]:
         assert not tf.loc[tf["feature_name"].str.startswith(f"{var}", na=False)].empty
     assert all(
@@ -121,10 +122,32 @@ def test_all_steps(
     assert (tf["coefficient_or_importance"] >= 0).all() and (
         tf["coefficient_or_importance"] <= 1
     ).all()
-    assert 0.4 <= tf.loc[0, "coefficient_or_importance"] <= 0.5
-    assert 0.1 <= tf.loc[1, "coefficient_or_importance"] <= 0.2
-    assert 0.1 <= tf.loc[2, "coefficient_or_importance"] <= 0.2
-    assert (tf.iloc[3:, 1] <= 0.1).all()
+
+    assert (
+        0.4
+        <= tf.query("feature_name == 'namelast_jw_imp'")[
+            "coefficient_or_importance"
+        ].item()
+        <= 0.5
+    )
+    assert (
+        0.1
+        <= tf.query("feature_name == 'namelast_jw_buckets_4'")[
+            "coefficient_or_importance"
+        ].item()
+        <= 0.2
+    )
+    assert (
+        0.2
+        <= tf.query("feature_name == 'state_distance_imp'")[
+            "coefficient_or_importance"
+        ].item()
+        <= 0.3
+    )
+    assert (
+        tf.query("feature_name == 'regionf_0'")["coefficient_or_importance"].item()
+        <= 0.1
+    )
 
 
 def test_step_2_bucketizer(spark, main, conf):


### PR DESCRIPTION
Fixes #105. Thanks to @jrbalch543 for the fix.

This PR fixes a bug in Training step 3 - save model metadata. Previously we extracted a single coefficient for each feature, even when the feature was categorical. But categorical features are one-hot encoded, and each of their categories (or "levels") gets its own coefficient. So we now explode the categorical features in step 3 and save the correct coefficient for each of the categories for the feature. The actual columns are still one-hot encoded as normal. To prevent this sort of issue from popping up again in the future, we've set `strict=True` for the zip of feature names and coefficients. This ensures that these two lists are the same length.

To be able to calculate the number of categories for each feature, we now save the `training_features_prepped` table in the previous training step. This table includes all comparison features along with the results of the pre-pipeline, which are imputed and one-hot encoded columns. This table is hidden because it is generally not useful to users unless they know what they're looking for and really want to dig into what hlink is doing in the pre-pipeline.