### PR TITLE
Error out on invalid categories in training data instead of creating a new category for them

### DIFF
--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -99,7 +99,6 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoder = OneHotEncoder(
             inputCols=categorical_comparison_features,
             outputCols=encoded_output_cols,
-            handleInvalid="keep",
             dropLast=False,
         )
         # feature_names = list((set(feature_names) - set(categorical_comparison_features)) | set(encoded_output_cols))
@@ -144,7 +143,6 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoder = OneHotEncoder(
             inputCols=categorical_pipeline_features,
             outputCols=encoded_output_cols,
-            handleInvalid="keep",
             dropLast=False,
         )
         # feature_names = list((set(feature_names) - set(categorical_pipeline_features)) | set(encoded_output_cols))

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -242,7 +242,7 @@ def test_step_1_OneHotEncoding(
     ]
     assert training_v.shape[0] == 9
     assert all(c in training_v.columns for c in columns_expected)
-    assert len(training_v["features_vector"][0]) == 5
+    assert len(training_v["features_vector"][0]) == 4
 
 
 def test_step_2_scale_values(
@@ -256,7 +256,7 @@ def test_step_2_scale_values(
     training_v = spark.table("model_eval_training_vectorized").toPandas()
 
     assert training_v.shape == (9, 9)
-    assert len(training_v["features_vector"][0]) == 5
+    assert len(training_v["features_vector"][0]) == 4
     assert training_v["features_vector"][0][0].round(2) == 2.85
 
 
@@ -427,35 +427,36 @@ def test_step_2_interact_categorial_vars(
     assert prepped_data.shape == (9, 11)
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")["regionf_onehotencoded"].iloc[0]
-    ) == [0, 1, 0, 0]
+    ) == [0, 1, 0]
     assert list(
         prepped_data.query("id_a == 20 and id_b == 50")["regionf_onehotencoded"].iloc[0]
-    ) == [0, 0, 1, 0]
+    ) == [0, 0, 1]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")["td_match_onehotencoded"].iloc[
             0
         ]
-    ) == [0, 1, 0]
+    ) == [0, 1]
     assert list(
         prepped_data.query("id_a == 20 and id_b == 50")["td_match_onehotencoded"].iloc[
             0
         ]
-    ) == [1, 0, 0]
+    ) == [1, 0]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 50")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+    ) == [0, 0, 1, 0, 0, 0]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]
+    ) == [0, 0, 0, 1, 0, 0]
     assert list(
         prepped_data.query("id_a == 30 and id_b == 50")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
+    ) == [0, 0, 0, 0, 0, 1]
+
     assert (
         len(
             list(
@@ -464,7 +465,7 @@ def test_step_2_interact_categorial_vars(
                 ]
             )
         )
-        == 17
+        == 10
     )
 
 
@@ -510,7 +511,7 @@ def test_step_2_VectorAssembly(
 
     vdf = spark.table("model_eval_training_vectorized").toPandas()
 
-    assert len(vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0]) == 6
+    assert len(vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0]) == 5
     assert 3187 in (
         vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0].values.round()
     )

--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -137,11 +137,11 @@ def test_all_steps(
         <= 0.2
     )
     assert (
-        0.2
+        0.1
         <= tf.query("feature_name == 'state_distance_imp'")[
             "coefficient_or_importance"
         ].item()
-        <= 0.3
+        <= 0.2
     )
     assert (
         tf.query("feature_name == 'regionf_0'")["coefficient_or_importance"].item()
@@ -195,12 +195,10 @@ def test_step_2_bucketizer(spark, main, conf):
         1,
         0,
         0,
-        0,
     ]
     assert list(prepped_data.query("test_id == 1")["features_vector"].iloc[0]) == [
         3,
         1,
-        0,
         0,
         0,
     ]
@@ -209,14 +207,12 @@ def test_step_2_bucketizer(spark, main, conf):
         0,
         1,
         0,
-        0,
     ]
     assert list(prepped_data.query("test_id == 6")["features_vector"].iloc[0]) == [
         11,
         0,
         0,
         1,
-        0,
     ]
 
     main.do_drop_all("")


### PR DESCRIPTION
Fixes #106.

This fixes a bug where we were adding an extra category to categorical variables. This category represented invalid/missing data. However, in hlink we are careful to have our categories cover all possible cases when we create a categorical variable. So we don't need the extra category; it was pretty much always zero.

Users can still handle missing categorical data by adding their own category in the training data or being careful about how they construct their categories. But now hlink does not do that implicitly, and it will error out if there is missing data for the category. Its behavior on classifying data is still the same - it would error out there before and it still will now. But now it will also error out on missing data in training data.