### PR TITLE
Tweak the format of Training step 3's output

### DIFF
--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -116,7 +116,10 @@ def test_all_steps(
     for var in training_conf["training"]["independent_vars"]:
         assert not tf.loc[tf["feature_name"].str.startswith(f"{var}", na=False)].empty
     assert all(
-        [col in ["feature_name", "coefficient_or_importance"] for col in tf.columns]
+        [
+            col in ["feature_name", "category", "coefficient_or_importance"]
+            for col in tf.columns
+        ]
     )
     assert (tf["coefficient_or_importance"] >= 0).all() and (
         tf["coefficient_or_importance"] <= 1
@@ -124,27 +127,27 @@ def test_all_steps(
 
     assert (
         0.4
-        <= tf.query("feature_name == 'namelast_jw_imp'")[
-            "coefficient_or_importance"
-        ].item()
+        <= tf.query("feature_name == 'namelast_jw'")["coefficient_or_importance"].item()
         <= 0.5
     )
     assert (
         0.1
-        <= tf.query("feature_name == 'namelast_jw_buckets_4'")[
+        <= tf.query("feature_name == 'namelast_jw_buckets' and category == 4")[
             "coefficient_or_importance"
         ].item()
         <= 0.2
     )
     assert (
         0.1
-        <= tf.query("feature_name == 'state_distance_imp'")[
+        <= tf.query("feature_name == 'state_distance'")[
             "coefficient_or_importance"
         ].item()
         <= 0.2
     )
     assert (
-        tf.query("feature_name == 'regionf_0'")["coefficient_or_importance"].item()
+        tf.query("feature_name == 'regionf' and category == 0")[
+            "coefficient_or_importance"
+        ].item()
         <= 0.1
     )
 
@@ -330,16 +333,14 @@ def test_step_3_interacted_categorical_features(
     tf = spark.table("training_feature_importances").toPandas()
     assert (
         0.0
-        <= tf.query("feature_name == 'regionf_interacted_namelast_jw_0'")[
-            "coefficient_or_importance"
-        ].item()
+        <= tf.query(
+            "feature_name == 'regionf_interacted_namelast_jw' and category == 0"
+        )["coefficient_or_importance"].item()
         <= 1.0
     )
     assert (
         0.4
-        <= tf.query("feature_name == 'namelast_jw_imp'")[
-            "coefficient_or_importance"
-        ].item()
+        <= tf.query("feature_name == 'namelast_jw'")["coefficient_or_importance"].item()
         <= 0.5
     )
 


### PR DESCRIPTION
Add a new `category` column and use that instead of suffixes to specify the category. Variables that aren't categorical have one row and a NULL in the category column. This changes the sort order for variables with more than 10 categories so that category 10 appears after categories 2-9 instead of before them, and similarly for other categories. I think it's also a cleaner way to indicate the category.

We are also now stripping the `_imp` suffix off of non-categorical column names as well as stripping the `_onehotencoded` off of categorical column names.