### PR TITLE
Add support for aliasing columns in only one input dataset #19

### DIFF
--- a/hlink/linking/core/column_mapping.py
+++ b/hlink/linking/core/column_mapping.py
@@ -9,6 +9,8 @@ import hlink.linking.core.transforms as transforms_core
 
 def select_column_mapping(column_mapping, df_selected, is_a, column_selects):
     name = column_mapping["column_name"]
+    if "rename" in column_mapping and not is_a:
+        df_selected = df_selected.withColumnRenamed(column_mapping["rename"], name)
     if "override_column_a" in column_mapping and is_a:
         override_name = column_mapping["override_column_a"]
         column_select = col(override_name)

--- a/hlink/scripts/lib/conf_validations.py
+++ b/hlink/scripts/lib/conf_validations.py
@@ -279,10 +279,13 @@ def check_column_mappings(config, df_a, df_b):
         column_name = c.get("column_name")
         set_value_column_a = c.get("set_value_column_a")
         set_value_column_b = c.get("set_value_column_b")
+        rename = c.get("rename")
         if not column_name:
             raise ValueError(
                 f"The following [[column_mappings]] has no 'column_name' attribute: {c}"
             )
+        if rename:
+            df_b = df_b.withColumnRenamed(rename, column_name)
         if set_value_column_a is None:
             if column_name.lower() not in [c.lower() for c in df_a.columns]:
                 if column_name not in columns_available:


### PR DESCRIPTION
This is meant to address things from Github Issue #19 and allow for a user to rename a column from B to fit the schema from A. This should be looked at after the other branch is merged (I forgot to swap back onto main before branching). 
Does this look like it should meaningfully address things? I'm not entirely sure if set_value_column_ would do the same thing, but this passes my initial testing to rename a column in B to fit A.