### PR TITLE
Revert to handleInvalid = "keep" for OneHotEncoder

### DIFF
--- a/hlink/linking/core/pipeline.py
+++ b/hlink/linking/core/pipeline.py
@@ -96,10 +96,17 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoded_output_cols = [
             x + "_onehotencoded" for x in categorical_comparison_features
         ]
+        # Here and below for categorical pipeline features we set handleInvalid
+        # to keep. This adds an extra category to the one-hot encoded result which
+        # represents "invalid categories" not seen in the training data that are
+        # encountered in the matching step. These categories generally receive a
+        # coefficient of 0.0 and don't contribute to the match probability. The
+        # alternative is to error out when we see these values, which we don't want.
         encoder = OneHotEncoder(
             inputCols=categorical_comparison_features,
             outputCols=encoded_output_cols,
             dropLast=False,
+            handleInvalid="keep",
         )
         # feature_names = list((set(feature_names) - set(categorical_comparison_features)) | set(encoded_output_cols))
         for x in categorical_comparison_features:
@@ -140,10 +147,13 @@ def generate_pipeline_stages(conf, ind_vars, tf, tconf):
         encoded_output_cols = [
             x + "_onehotencoded" for x in categorical_pipeline_features
         ]
+        # See the comment on categorical pipeline features above for reasoning on
+        # handleInvalid="keep".
         encoder = OneHotEncoder(
             inputCols=categorical_pipeline_features,
             outputCols=encoded_output_cols,
             dropLast=False,
+            handleInvalid="keep",
         )
         # feature_names = list((set(feature_names) - set(categorical_pipeline_features)) | set(encoded_output_cols))
         for x in categorical_pipeline_features:

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -242,7 +242,7 @@ def test_step_1_OneHotEncoding(
     ]
     assert training_v.shape[0] == 9
     assert all(c in training_v.columns for c in columns_expected)
-    assert len(training_v["features_vector"][0]) == 4
+    assert len(training_v["features_vector"][0]) == 5
 
 
 def test_step_2_scale_values(
@@ -256,7 +256,7 @@ def test_step_2_scale_values(
     training_v = spark.table("model_eval_training_vectorized").toPandas()
 
     assert training_v.shape == (9, 9)
-    assert len(training_v["features_vector"][0]) == 4
+    assert len(training_v["features_vector"][0]) == 5
     assert training_v["features_vector"][0][0].round(2) == 2.85
 
 
@@ -427,35 +427,35 @@ def test_step_2_interact_categorial_vars(
     assert prepped_data.shape == (9, 11)
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")["regionf_onehotencoded"].iloc[0]
-    ) == [0, 1, 0]
+    ) == [0, 1, 0, 0]
     assert list(
         prepped_data.query("id_a == 20 and id_b == 50")["regionf_onehotencoded"].iloc[0]
-    ) == [0, 0, 1]
+    ) == [0, 0, 1, 0]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")["td_match_onehotencoded"].iloc[
             0
         ]
-    ) == [0, 1]
+    ) == [0, 1, 0]
     assert list(
         prepped_data.query("id_a == 20 and id_b == 50")["td_match_onehotencoded"].iloc[
             0
         ]
-    ) == [1, 0]
+    ) == [1, 0, 0]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 50")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 1, 0, 0, 0]
+    ) == [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
     assert list(
         prepped_data.query("id_a == 10 and id_b == 10")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 0, 1, 0, 0]
+    ) == [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]
     assert list(
         prepped_data.query("id_a == 30 and id_b == 50")[
             "regionf_interacted_tdmatch"
         ].iloc[0]
-    ) == [0, 0, 0, 0, 0, 1]
+    ) == [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
 
     assert (
         len(
@@ -465,7 +465,7 @@ def test_step_2_interact_categorial_vars(
                 ]
             )
         )
-        == 10
+        == 17
     )
 
 
@@ -511,7 +511,7 @@ def test_step_2_VectorAssembly(
 
     vdf = spark.table("model_eval_training_vectorized").toPandas()
 
-    assert len(vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0]) == 5
+    assert len(vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0]) == 6
     assert 3187 in (
         vdf.query("id_a == 20 and id_b == 30")["features_vector"].iloc[0].values.round()
     )

--- a/hlink/tests/training_test.py
+++ b/hlink/tests/training_test.py
@@ -142,7 +142,7 @@ def test_all_steps(
         <= tf.query("feature_name == 'state_distance'")[
             "coefficient_or_importance"
         ].item()
-        <= 0.2
+        <= 0.21
     )
     assert (
         tf.query("feature_name == 'regionf' and category == 0")[
@@ -198,10 +198,12 @@ def test_step_2_bucketizer(spark, main, conf):
         1,
         0,
         0,
+        0,
     ]
     assert list(prepped_data.query("test_id == 1")["features_vector"].iloc[0]) == [
         3,
         1,
+        0,
         0,
         0,
     ]
@@ -210,12 +212,14 @@ def test_step_2_bucketizer(spark, main, conf):
         0,
         1,
         0,
+        0,
     ]
     assert list(prepped_data.query("test_id == 6")["features_vector"].iloc[0]) == [
         11,
         0,
         0,
         1,
+        0,
     ]
 
     main.do_drop_all("")


### PR DESCRIPTION
I've added a comment explaining the reasoning for this. I misunderstood some details when I decided to change to handleInvalid="error". We do want handleInvalid="keep". We don't expect that we'll trigger it very often though.

With handleInvalid set to error, we will error out in the matching step when we see categories that we didn't train on. This isn't super likely, but can happen in some cases. We'd rather not error out on these cases and instead create a new category for them which doesn't contribute to the match probability.