### PR TITLE
Put the config file name in the script prompt

### DIFF
--- a/hlink/scripts/main_loop.py
+++ b/hlink/scripts/main_loop.py
@@ -47,9 +47,6 @@ def split_and_check_args(expected_count):
 class Main(Cmd):
     """Main program which handles user input. See https://docs.python.org/3/library/cmd.html for more information."""
 
-    prompt = "hlink $ "
-    intro = "Welcome to hlink. Type ? to list commands and q to quit.\n"
-
     def __init__(
         self,
         link_run,
@@ -57,6 +54,8 @@ class Main(Cmd):
     ):
         self.link_run = link_run
         self.spark = self.link_run.spark
+        self.prompt = "hlink $ "
+        self.intro = "Welcome to hlink. Type ? to list commands and q to quit.\n"
 
         if start_task is None:
             self.current_link_task = self.link_run.preprocessing

--- a/hlink/scripts/main_loop.py
+++ b/hlink/scripts/main_loop.py
@@ -51,10 +51,12 @@ class Main(Cmd):
         self,
         link_run,
         start_task: Optional[str] = None,
+        run_name: Optional[str] = None,
     ):
         self.link_run = link_run
         self.spark = self.link_run.spark
-        self.prompt = "hlink $ "
+
+        self.prompt = "hlink $ " if run_name is None else f"hlink ({run_name}) $ "
         self.intro = "Welcome to hlink. Type ? to list commands and q to quit.\n"
 
         if start_task is None:


### PR DESCRIPTION
Closes #122.

This is a small feature to display the name of the config file in the script prompt. This makes it easier to tell which script you're running on during long hlink sessions.