### PR TITLE
Fix a bug with the override_column_X attributes in conf_validations.py

### DIFF
--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -115,26 +115,32 @@ class LinkStepExplode(LinkStep):
                 expand_length = exploding_column["expand_length"]
                 derived_from_column = exploding_column["derived_from"]
                 explode_selects = [
-                    explode(self._expand(derived_from_column, expand_length)).alias(
-                        exploding_column_name
+                    (
+                        explode(self._expand(derived_from_column, expand_length)).alias(
+                            exploding_column_name
+                        )
+                        if exploding_column_name == column
+                        else column
                     )
-                    if exploding_column_name == column
-                    else column
                     for column in all_column_names
                 ]
             else:
                 explode_selects = [
-                    explode(col(exploding_column_name)).alias(exploding_column_name)
-                    if exploding_column_name == c
-                    else c
+                    (
+                        explode(col(exploding_column_name)).alias(exploding_column_name)
+                        if exploding_column_name == c
+                        else c
+                    )
                     for c in all_column_names
                 ]
             if "dataset" in exploding_column:
                 derived_from_column = exploding_column["derived_from"]
                 explode_selects_with_derived_column = [
-                    col(derived_from_column).alias(exploding_column_name)
-                    if exploding_column_name == column
-                    else column
+                    (
+                        col(derived_from_column).alias(exploding_column_name)
+                        if exploding_column_name == column
+                        else column
+                    )
                     for column in all_column_names
                 ]
                 if exploding_column["dataset"] == "a":

--- a/hlink/scripts/lib/conf_validations.py
+++ b/hlink/scripts/lib/conf_validations.py
@@ -276,22 +276,41 @@ def check_column_mappings(config, df_a, df_b):
         column_name = c.get("column_name")
         set_value_column_a = c.get("set_value_column_a")
         set_value_column_b = c.get("set_value_column_b")
+        override_column_a = c.get("override_column_a")
+        override_column_b = c.get("override_column_b")
+
         if not column_name:
             raise ValueError(
                 f"The following [[column_mappings]] has no 'column_name' attribute: {c}"
             )
         if set_value_column_a is None:
-            if column_name.lower() not in [c.lower() for c in df_a.columns]:
-                if column_name not in columns_available:
+            datasource_a_columns = [column.lower() for column in df_a.columns]
+
+            if override_column_a is not None:
+                if override_column_a.lower() not in datasource_a_columns:
                     raise ValueError(
-                        f"Within a [[column_mappings]] the column_name: '{column_name}' does not exist in datasource_a and no previous [[column_mapping]] alias exists for it. \nColumn mapping: {c}. \nAvailable columns: \n {df_a.columns}"
+                        f"Within a [[column_mappings]] the override_column_a column '{override_column_a}' does not exist in datasource_a.\nColumn mapping: {c}.\nAvailable columns: {df_a.columns}"
                     )
+            else:
+                if column_name.lower() not in datasource_a_columns:
+                    if column_name not in columns_available:
+                        raise ValueError(
+                            f"Within a [[column_mappings]] the column_name: '{column_name}' does not exist in datasource_a and no previous [[column_mapping]] alias exists for it. \nColumn mapping: {c}. \nAvailable columns: \n {df_a.columns}"
+                        )
         if set_value_column_b is None:
-            if column_name.lower() not in [c.lower() for c in df_b.columns]:
-                if column_name not in columns_available:
+            datasource_b_columns = [column.lower() for column in df_b.columns]
+
+            if override_column_b is not None:
+                if override_column_b.lower() not in datasource_b_columns:
                     raise ValueError(
-                        f"Within a [[column_mappings]] the column_name: '{column_name}' does not exist in datasource_b and no previous [[column_mapping]] alias exists for it. Column mapping: {c}. Available columns: \n {df_b.columns}"
+                        f"Within a [[column_mappings]] the override_column_b column '{override_column_b}' does not exist in datasource_b.\nColumn mapping: {c}.\nAvailable columns: {df_b.columns}"
                     )
+            else:
+                if column_name.lower() not in datasource_b_columns:
+                    if column_name not in columns_available:
+                        raise ValueError(
+                            f"Within a [[column_mappings]] the column_name: '{column_name}' does not exist in datasource_b and no previous [[column_mapping]] alias exists for it. Column mapping: {c}. Available columns: \n {df_b.columns}"
+                        )
         if alias in columns_available:
             duplicates.append(alias)
         elif not alias and column_name in columns_available:

--- a/hlink/scripts/lib/conf_validations.py
+++ b/hlink/scripts/lib/conf_validations.py
@@ -306,7 +306,9 @@ def check_column_mappings_column_available(
             )
 
 
-def check_column_mappings(config, df_a, df_b):
+def check_column_mappings(
+    config: dict[str, Any], df_a: DataFrame, df_b: DataFrame
+) -> list[str]:
     column_mappings = config.get("column_mappings")
     if not column_mappings:
         raise ValueError("No [[column_mappings]] exist in the conf file.")

--- a/hlink/tests/conf_validations_test.py
+++ b/hlink/tests/conf_validations_test.py
@@ -1,8 +1,10 @@
 import os
 import pytest
 
+from pyspark.sql import SparkSession
+
 from hlink.configs.load_config import load_conf_file
-from hlink.scripts.lib.conf_validations import analyze_conf
+from hlink.scripts.lib.conf_validations import analyze_conf, check_column_mappings
 from hlink.linking.link_run import LinkRun
 
 
@@ -25,3 +27,37 @@ def test_invalid_conf(conf_dir_path, spark, conf_name, error_msg):
 
     with pytest.raises(ValueError, match=error_msg):
         analyze_conf(link_run)
+
+
+def test_check_column_mappings_mappings_missing(spark: SparkSession) -> None:
+    """
+    The config must have a column_mappings section.
+    """
+    config = {}
+    df_a = spark.createDataFrame([[1], [2], [3]], ["a"])
+    df_b = spark.createDataFrame([[4], [5], [6]], ["b"])
+
+    with pytest.raises(
+        ValueError, match=r"No \[\[column_mappings\]\] exist in the conf file"
+    ):
+        check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_no_column_name(spark: SparkSession) -> None:
+    """
+    Each column mapping in the config must have a column_name attribute.
+    """
+    config = {
+        "column_mappings": [{"column_name": "AGE", "alias": "age"}, {"alias": "height"}]
+    }
+    df_a = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+    df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+
+    df_a.show()
+    df_b.show()
+
+    expected_err = (
+        r"The following \[\[column_mappings\]\] has no 'column_name' attribute:"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        check_column_mappings(config, df_a, df_b)

--- a/hlink/tests/conf_validations_test.py
+++ b/hlink/tests/conf_validations_test.py
@@ -179,3 +179,47 @@ def test_check_column_mappings_override_column_b(spark: SparkSession) -> None:
     df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
 
     check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_override_column_a_not_present(
+    spark: SparkSession,
+) -> None:
+    """
+    The override_column_a column must be present in datasource A.
+    """
+    config = {
+        "column_mappings": [
+            {"column_name": "AGE", "override_column_a": "oops_not_there"}
+        ]
+    }
+    df_a = spark.createDataFrame([[20], [40], [60]], ["ageColumn"])
+    df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+
+    expected_err = (
+        r"Within a \[\[column_mappings\]\] the override_column_a column "
+        "'oops_not_there' does not exist in datasource_a"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_override_column_b_not_present(
+    spark: SparkSession,
+) -> None:
+    """
+    The override_column_b column must be present in datasource B.
+    """
+    config = {
+        "column_mappings": [
+            {"column_name": "AGE", "override_column_b": "oops_not_there"}
+        ]
+    }
+    df_a = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+    df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+
+    expected_err = (
+        r"Within a \[\[column_mappings\]\] the override_column_b column "
+        "'oops_not_there' does not exist in datasource_b"
+    )
+    with pytest.raises(ValueError, match=expected_err):
+        check_column_mappings(config, df_a, df_b)

--- a/hlink/tests/conf_validations_test.py
+++ b/hlink/tests/conf_validations_test.py
@@ -151,3 +151,31 @@ def test_check_column_mappings_previous_mappings_are_available(
     df_b = spark.createDataFrame([[20], [40], [60]], ["AGE"])
 
     check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_override_column_a(spark: SparkSession) -> None:
+    """
+    The override_column_a attribute lets you control which column you read from
+    in datasource A.
+    """
+    config = {
+        "column_mappings": [{"column_name": "AGE", "override_column_a": "ageColumn"}]
+    }
+    df_a = spark.createDataFrame([[20], [40], [60]], ["ageColumn"])
+    df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+
+    check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_override_column_b(spark: SparkSession) -> None:
+    """
+    The override_column_b attribute lets you control which column you read from
+    in datasource B.
+    """
+    config = {
+        "column_mappings": [{"column_name": "ageColumn", "override_column_b": "AGE"}]
+    }
+    df_a = spark.createDataFrame([[20], [40], [60]], ["ageColumn"])
+    df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+
+    check_column_mappings(config, df_a, df_b)

--- a/hlink/tests/conf_validations_test.py
+++ b/hlink/tests/conf_validations_test.py
@@ -73,7 +73,7 @@ def test_check_column_mappings_column_name_not_available_datasource_a(
     df_b = spark.createDataFrame([[70, 123], [50, 123], [30, 123]], ["AGE", "HEIGHT"])
 
     expected_err = (
-        r"Within a \[\[column_mappings\]\] the column_name: 'HEIGHT' "
+        r"Within a \[\[column_mappings\]\] the column_name 'HEIGHT' "
         r"does not exist in datasource_a and no previous \[\[column_mapping\]\] "
         "alias exists for it"
     )
@@ -110,7 +110,7 @@ def test_check_column_mappings_column_name_not_available_datasource_b(
     df_b = spark.createDataFrame([[20], [40], [60]], ["AGE"])
 
     expected_err = (
-        r"Within a \[\[column_mappings\]\] the column_name: 'HEIGHT' "
+        r"Within a \[\[column_mappings\]\] the column_name 'HEIGHT' "
         r"does not exist in datasource_b and no previous \[\[column_mapping\]\] "
         "alias exists for it"
     )

--- a/hlink/tests/conf_validations_test.py
+++ b/hlink/tests/conf_validations_test.py
@@ -53,11 +53,101 @@ def test_check_column_mappings_no_column_name(spark: SparkSession) -> None:
     df_a = spark.createDataFrame([[20], [40], [60]], ["AGE"])
     df_b = spark.createDataFrame([[70], [50], [30]], ["AGE"])
 
-    df_a.show()
-    df_b.show()
-
     expected_err = (
         r"The following \[\[column_mappings\]\] has no 'column_name' attribute:"
     )
     with pytest.raises(ValueError, match=expected_err):
         check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_column_name_not_available_datasource_a(
+    spark: SparkSession,
+) -> None:
+    """
+    Column mappings may only use column_names that appear in datasource A or a
+    previous column mapping.
+    """
+    config = {"column_mappings": [{"column_name": "HEIGHT"}]}
+
+    df_a = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+    df_b = spark.createDataFrame([[70, 123], [50, 123], [30, 123]], ["AGE", "HEIGHT"])
+
+    expected_err = (
+        r"Within a \[\[column_mappings\]\] the column_name: 'HEIGHT' "
+        r"does not exist in datasource_a and no previous \[\[column_mapping\]\] "
+        "alias exists for it"
+    )
+
+    with pytest.raises(ValueError, match=expected_err):
+        check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_set_value_column_a_does_not_need_column(
+    spark: SparkSession,
+) -> None:
+    """
+    When set_value_column_a is present for a column mapping, that column does not
+    need to be present in datasource A.
+    """
+    config = {"column_mappings": [{"column_name": "HEIGHT", "set_value_column_a": 125}]}
+
+    df_a = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+    df_b = spark.createDataFrame([[70, 123], [50, 123], [30, 123]], ["AGE", "HEIGHT"])
+
+    check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_column_name_not_available_datasource_b(
+    spark: SparkSession,
+) -> None:
+    """
+    Column mappings may only use column_names that appear in datasource B or a
+    previous column mapping.
+    """
+    config = {"column_mappings": [{"column_name": "HEIGHT"}]}
+
+    df_a = spark.createDataFrame([[70, 123], [50, 123], [30, 123]], ["AGE", "HEIGHT"])
+    df_b = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+
+    expected_err = (
+        r"Within a \[\[column_mappings\]\] the column_name: 'HEIGHT' "
+        r"does not exist in datasource_b and no previous \[\[column_mapping\]\] "
+        "alias exists for it"
+    )
+
+    with pytest.raises(ValueError, match=expected_err):
+        check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_set_value_column_b_does_not_need_column(
+    spark: SparkSession,
+) -> None:
+    """
+    When set_value_column_b is present for a column mapping, that column does not
+    need to be present in datasource B.
+    """
+    config = {"column_mappings": [{"column_name": "HEIGHT", "set_value_column_b": 125}]}
+
+    df_a = spark.createDataFrame([[70, 123], [50, 123], [30, 123]], ["AGE", "HEIGHT"])
+    df_b = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+
+    check_column_mappings(config, df_a, df_b)
+
+
+def test_check_column_mappings_previous_mappings_are_available(
+    spark: SparkSession,
+) -> None:
+    """
+    Columns created in a previous column mapping can be used in other column
+    mappings.
+    """
+    config = {
+        "column_mappings": [
+            {"column_name": "AGE", "alias": "AGE_HLINK"},
+            {"column_name": "AGE_HLINK", "alias": "AGE_HLINK2"},
+        ]
+    }
+    df_a = spark.createDataFrame([[70], [50], [30]], ["AGE"])
+    df_b = spark.createDataFrame([[20], [40], [60]], ["AGE"])
+
+    check_column_mappings(config, df_a, df_b)


### PR DESCRIPTION
Fixes #130.

In issue #118 we documented the override_column_a and override_column_b attributes for column mappings and added some tests for those. I forgot to check the config validation though, and there was no logic in there for handling the override_column_X attributes. So if you used the override_column_X attributes in a column mapping, you'd still get a config validation error from the conf_validations module. If you decided to run hlink anyways, it probably ran without errors. The bug was just in the analysis code, not in the core module code.

I've added some more unit tests for this section of the code and refactored the `check_column_mappings()` function to make it easier to work with.

The changes to [hlink/linking/matching/link_step_explode.py](https://github.com/ipums/hlink/compare/bug_fix_column_mappings_validation?expand=1#diff-3b9d60c8d80f07e63a54a20c8a163f8db2e3f580693ee0c7bcbe2a6c65ffefcf) are `black` formatting changes. `black` has updated since we last made a change to hlink.