### PR TITLE
Support blocking sections with multiple exploded columns

### DIFF
--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -127,17 +127,13 @@ class LinkStepExplode(LinkStep):
 
                 explode_col_expr = explode(
                     self._expand(derived_from_column, expand_length)
-                ).alias(exploding_column_name)
-            else:
-                explode_col_expr = explode(col(exploding_column_name)).alias(
-                    exploding_column_name
                 )
+            else:
+                explode_col_expr = explode(col(exploding_column_name))
 
             if "dataset" in exploding_column:
                 derived_from_column = exploding_column["derived_from"]
-                no_explode_col_expr = col(derived_from_column).alias(
-                    exploding_column_name
-                )
+                no_explode_col_expr = col(derived_from_column)
 
                 if exploding_column["dataset"] == "a":
                     expr = explode_col_expr if is_a else no_explode_col_expr

--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -153,7 +153,7 @@ class LinkStepExplode(LinkStep):
         # be a breaking change to remove this. We'd have to look into the
         # ramifications.
         if len(all_exploding_columns) > 0:
-            exploded_df = exploded_df.select(*all_column_names)
+            exploded_df = exploded_df.select(sorted(all_column_names))
 
         return exploded_df
 

--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -124,49 +124,41 @@ class LinkStepExplode(LinkStep):
             if exploding_column.get("expand_length", False):
                 expand_length = exploding_column["expand_length"]
                 derived_from_column = exploding_column["derived_from"]
-                explode_selects = [
-                    (
-                        explode(self._expand(derived_from_column, expand_length)).alias(
-                            exploding_column_name
-                        )
-                        if exploding_column_name == column
-                        else column
-                    )
-                    for column in all_column_names
-                ]
+
+                explode_col_expr = explode(
+                    self._expand(derived_from_column, expand_length)
+                ).alias(exploding_column_name)
             else:
-                explode_selects = [
-                    (
-                        explode(col(exploding_column_name)).alias(exploding_column_name)
-                        if exploding_column_name == c
-                        else c
-                    )
-                    for c in all_column_names
-                ]
+                explode_col_expr = explode(col(exploding_column_name)).alias(
+                    exploding_column_name
+                )
+
             if "dataset" in exploding_column:
                 derived_from_column = exploding_column["derived_from"]
-                explode_selects_with_derived_column = [
-                    (
-                        col(derived_from_column).alias(exploding_column_name)
-                        if exploding_column_name == column
-                        else column
-                    )
-                    for column in all_column_names
-                ]
+                no_explode_col_expr = col(derived_from_column).alias(
+                    exploding_column_name
+                )
+
                 if exploding_column["dataset"] == "a":
-                    exploded_df = (
-                        exploded_df.select(explode_selects)
-                        if is_a
-                        else exploded_df.select(explode_selects_with_derived_column)
-                    )
+                    expr = explode_col_expr if is_a else no_explode_col_expr
+                    exploded_df = exploded_df.withColumn(exploding_column_name, expr)
                 elif exploding_column["dataset"] == "b":
-                    exploded_df = (
-                        exploded_df.select(explode_selects)
-                        if not (is_a)
-                        else exploded_df.select(explode_selects_with_derived_column)
-                    )
+                    expr = explode_col_expr if not is_a else no_explode_col_expr
+                    exploded_df = exploded_df.withColumn(exploding_column_name, expr)
             else:
-                exploded_df = exploded_df.select(explode_selects)
+                exploded_df = exploded_df.withColumn(
+                    exploding_column_name, explode_col_expr
+                )
+
+        # If there are exploding columns, then select out "all_column_names".
+        # Otherwise, just let all of the columns through without selecting
+        # specific ones. I believe this is an artifact of a previous
+        # implementation, but the tests currently enforce it. It may or may not
+        # be a breaking change to remove this. We'd have to look into the
+        # ramifications.
+        if len(all_exploding_columns) > 0:
+            exploded_df = exploded_df.select(*all_column_names)
+
         return exploded_df
 
     def _expand(self, column_name: str, expand_length: int) -> Column:

--- a/hlink/tests/matching_blocking_explode_test.py
+++ b/hlink/tests/matching_blocking_explode_test.py
@@ -124,6 +124,44 @@ def test_blocking_multi_layer_comparison(
         ) or (row["namelast_jw_x"] < 0.7)
 
 
+def test_blocking_multiple_exploded_columns(
+    spark, blocking_explode_conf, matching_test_input, matching
+):
+    table_a, table_b = matching_test_input
+    table_a.createOrReplaceTempView("prepped_df_a")
+    table_b.createOrReplaceTempView("prepped_df_b")
+
+    blocking_explode_conf["blocking"] = [
+        {
+            "column_name": "birthyr_3",
+            "dataset": "a",
+            "derived_from": "birthyr",
+            "expand_length": 3,
+            "explode": True,
+        },
+        {
+            "column_name": "birthyr_4",
+            "dataset": "a",
+            "derived_from": "birthyr",
+            "expand_length": 4,
+            "explode": True,
+        },
+        {"column_name": "sex"},
+    ]
+
+    matching.run_step(0)
+
+    exploded_a = spark.table("exploded_df_a").toPandas()
+    exploded_b = spark.table("exploded_df_b").toPandas()
+
+    assert "sex" in exploded_a.columns
+    assert "birthyr_3" in exploded_a.columns
+    assert "birthyr_4" in exploded_a.columns
+    assert "sex" in exploded_b.columns
+    assert "birthyr_3" in exploded_b.columns
+    assert "birthyr_4" in exploded_b.columns
+
+
 def test_blocking_or_groups(
     spark, blocking_or_groups_conf, matching_or_groups_test_input, matching
 ):


### PR DESCRIPTION
Fixes #142.

This PR fixes a bug in the matching explode step which seems like it has been around for a long time. When a user set `explode = true` for more than one blocking column, they got an error like this:

```
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `<exploded_column>` cannot be resolved.
```

This error happened in the loop in the `_explode()` function. The loop constructed each exploded column one-by-one and then selected it and the other columns out of `exploded_df`. The problem was that each iteration tried to select *all* of the blocking columns out of `exploded_df`, even though the loop hadn't run for all of the exploded columns yet. This is why the first iteration of the loop threw an unresolved column error.

To fix this, I've switched the loop to add the exploded columns to `exploded_df` one-by-one with `withColumn()`. This actually ended up simplifying the loop pretty substantially because we can focus on a single column at a time instead of handling all of the columns to select out with list comprehensions. The results are the same.

I found another possible bug when working on this. In the previous implementation, we selected `all_column_names` out of `exploded_df` if and only if there was at least one exploded column. The tests depend on this behavior. So I've added some logic to replicate the behavior and a comment explaining it. Changing this behavior is probably technically a breaking change because it changes the columns of the exploded_df_a and exploded_df_b tables. This might have ramifications for later tasks as well. One thing I did change is the order of the columns in exploded_df_a and exploded_df_b, since previously we were selecting with an unordered set. I've sorted the columns so that they aren't in a random order in the output tables.