### PR TITLE
Improve model_exploration step 2 output

### DIFF
--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -595,6 +595,7 @@ def _append_results(
     params: dict[str, Any],
 ) -> pd.DataFrame:
     # run.pop("type")
+    print(results_df)
 
     new_desc = pd.DataFrame(
         {

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -137,18 +137,18 @@ class LinkStepTrainTestModels(LinkStep):
                     first = False
 
                 i = 0
-                for at, tr in threshold_matrix:
+                for alpha_threshold, threshold_ratio in threshold_matrix:
                     predictions = threshold_core.predict_using_thresholds(
                         predictions_tmp,
-                        at,
-                        tr,
+                        alpha_threshold,
+                        threshold_ratio,
                         config[training_conf],
                         config["id_column"],
                     )
                     predict_train = threshold_core.predict_using_thresholds(
                         predict_train_tmp,
-                        at,
-                        tr,
+                        alpha_threshold,
+                        threshold_ratio,
                         config[training_conf],
                         config["id_column"],
                     )
@@ -160,8 +160,8 @@ class LinkStepTrainTestModels(LinkStep):
                         model,
                         results_dfs[i],
                         otd_data,
-                        at,
-                        tr,
+                        alpha_threshold,
+                        threshold_ratio,
                         pr_auc,
                     )
                     i += 1
@@ -252,8 +252,8 @@ class LinkStepTrainTestModels(LinkStep):
         model: Model,
         results_df: pd.DataFrame,
         otd_data: dict[str, Any] | None,
-        at: float,
-        tr: float,
+        alpha_threshold: float,
+        threshold_ratio: float,
         pr_auc: float,
     ) -> pd.DataFrame:
         table_prefix = self.task.table_prefix
@@ -293,8 +293,8 @@ class LinkStepTrainTestModels(LinkStep):
                 "test_mcc": [test_mcc],
                 "train_mcc": [train_mcc],
                 "model_id": [model],
-                "alpha_threshold": [at],
-                "threshold_ratio": [tr],
+                "alpha_threshold": [alpha_threshold],
+                "threshold_ratio": [threshold_ratio],
             },
         )
         return pd.concat([results_df, new_results], ignore_index=True)

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -74,9 +74,9 @@ class LinkStepTrainTestModels(LinkStep):
             f"each of these has {n_training_iterations} train-test splits to test on"
         )
         for run_index, run in enumerate(model_parameters, 1):
-            logger.info(
-                f"Starting run {run_index} of {len(model_parameters)} with these parameters: {run}"
-            )
+            run_start_info = f"Starting run {run_index} of {len(model_parameters)} with these parameters: {run}"
+            print(run_start_info)
+            logger.info(run_start_info)
             params = run.copy()
             model_type = params.pop("type")
 
@@ -103,9 +103,9 @@ class LinkStepTrainTestModels(LinkStep):
 
             first = True
             for split_index, (training_data, test_data) in enumerate(splits, 1):
-                logger.debug(
-                    f"Training and testing the model on train-test split {split_index} of {n_training_iterations}"
-                )
+                split_start_info = f"Training and testing the model on train-test split {split_index} of {n_training_iterations}"
+                print(split_start_info)
+                logger.debug(split_start_info)
                 training_data.cache()
                 test_data.cache()
 
@@ -139,7 +139,7 @@ class LinkStepTrainTestModels(LinkStep):
                 param_text = np.full(precision.shape, f"{model_type}_{params}")
 
                 pr_auc = auc(recall, precision)
-                print(f"Area under PR curve: {pr_auc}")
+                print(f"The area under the precision-recall curve is {pr_auc}")
 
                 if first:
                     prc = pd.DataFrame(
@@ -287,7 +287,6 @@ class LinkStepTrainTestModels(LinkStep):
     ) -> pd.DataFrame:
         table_prefix = self.task.table_prefix
 
-        print("Evaluating model performance...")
         # write to sql tables for testing
         predictions.createOrReplaceTempView(f"{table_prefix}predictions")
         predict_train.createOrReplaceTempView(f"{table_prefix}predict_train")
@@ -596,7 +595,6 @@ def _append_results(
     params: dict[str, Any],
 ) -> pd.DataFrame:
     # run.pop("type")
-    print(results_df)
 
     new_desc = pd.DataFrame(
         {


### PR DESCRIPTION
Closes #154.

This PR adds some type hints and doc comments to model_exploration.link_step_train_and_test_models, adds logging statements, and makes the output less chatty and more helpful. This step can take quite a while when the parameter grid to search is large, so the logging statements and print statements are really important for knowing how much progress it has made. The logging statements also give us timestamps, which can be helpful for finding and diagnosing performance issues.