### PR TITLE
Support setting the app name via SparkConnection

### DIFF
--- a/hlink/spark/session.py
+++ b/hlink/spark/session.py
@@ -21,12 +21,15 @@ from pyspark.sql.types import (
 class SparkConnection:
     """Handles initialization of spark session and connection to local cluster."""
 
-    def __init__(self, derby_dir, warehouse_dir, tmp_dir, python, db_name):
+    def __init__(
+        self, derby_dir, warehouse_dir, tmp_dir, python, db_name, app_name="linking"
+    ):
         self.derby_dir = derby_dir
         self.warehouse_dir = warehouse_dir
         self.db_name = db_name
         self.tmp_dir = tmp_dir
         self.python = python
+        self.app_name = app_name
 
     def spark_conf(self, executor_cores, executor_memory, driver_memory, cores):
         spark_package_path = os.path.dirname(hlink.spark.__file__)
@@ -44,7 +47,7 @@ class SparkConnection:
             )
             .set("spark.executorEnv.SPARK_LOCAL_DIRS", self.tmp_dir)
             .set("spark.sql.legacy.allowUntypedScalaUDF", True)
-            .setAppName("linking")
+            .setAppName(self.app_name)
             # .set("spark.executor.cores", executor_cores) \
         )
         if executor_memory:

--- a/hlink/tests/spark_connection_test.py
+++ b/hlink/tests/spark_connection_test.py
@@ -14,3 +14,20 @@ def test_app_name_defaults_to_linking(tmp_path: Path) -> None:
     spark = connection.local(cores=1, executor_memory="1G")
     app_name = spark.conf.get("spark.app.name")
     assert app_name == "linking"
+
+
+def test_app_name_argument(tmp_path: Path) -> None:
+    derby_dir = tmp_path / "derby"
+    warehouse_dir = tmp_path / "warehouse"
+    tmp_dir = tmp_path / "tmp"
+    connection = SparkConnection(
+        derby_dir,
+        warehouse_dir,
+        tmp_dir,
+        sys.executable,
+        "test",
+        app_name="test_app_name",
+    )
+    spark = connection.local(cores=1, executor_memory="1G")
+    app_name = spark.conf.get("spark.app.name")
+    assert app_name == "test_app_name"

--- a/hlink/tests/spark_connection_test.py
+++ b/hlink/tests/spark_connection_test.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+from hlink.spark.session import SparkConnection
+
+
+def test_app_name_defaults_to_linking(tmp_path: Path) -> None:
+    derby_dir = tmp_path / "derby"
+    warehouse_dir = tmp_path / "warehouse"
+    tmp_dir = tmp_path / "tmp"
+    connection = SparkConnection(
+        derby_dir, warehouse_dir, tmp_dir, sys.executable, "test"
+    )
+    spark = connection.local(cores=1, executor_memory="1G")
+    app_name = spark.conf.get("spark.app.name")
+    assert app_name == "linking"


### PR DESCRIPTION
This PR adds an optional `app_name` argument to `SparkConnection` which supports setting the Spark `spark.app.name` configuration setting. The default behavior is unchanged; by default the app name is "linking".

This app name shows up in the Spark UI and possibly in resource managers like Mesos as well. Being able to set this for each run helps to distinguish between different runs.