### PR TITLE
Add Randomized Parameter Search

### DIFF
--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -704,13 +704,19 @@ def _choose_randomized_parameters(
         # the parameter should be sampled.
         elif isinstance(value, collections.abc.Mapping):
             distribution = value["distribution"]
-            low = value["low"]
-            high = value["high"]
 
             if distribution == "randint":
+                low = value["low"]
+                high = value["high"]
                 parameter_choices[key] = rng.randint(low, high)
             elif distribution == "uniform":
+                low = value["low"]
+                high = value["high"]
                 parameter_choices[key] = rng.uniform(low, high)
+            elif distribution == "normal":
+                mean = value["mean"]
+                stdev = value["standard_deviation"]
+                parameter_choices[key] = rng.normalvariate(mean, stdev)
             else:
                 raise ValueError("unknown distribution")
         # All other types (including strings) are passed through unchanged.

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -695,10 +695,8 @@ def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str,
     parameter_choices = dict()
 
     for key, value in model_parameters.items():
-        if key == "type":
-            parameter_choices[key] = value
         # If it's a Sequence (usually list), choose one of the values at random.
-        elif isinstance(value, collections.abc.Sequence):
+        if isinstance(value, collections.abc.Sequence):
             parameter_choices[key] = random.choice(value)
         # If it's a Mapping (usually dict), it defines a distribution from which
         # the parameter should be sampled.
@@ -757,7 +755,14 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             return_parameters = []
             for _ in range(num_samples):
                 parameter_spec = random.choice(model_parameters)
-                randomized = _choose_randomized_parameters(parameter_spec)
+                model_type = parameter_spec["type"]
+                sample_parameters = dict(
+                    (key, value)
+                    for (key, value) in parameter_spec.items()
+                    if key != "type"
+                )
+                randomized = _choose_randomized_parameters(sample_parameters)
+                randomized["type"] = model_type
                 return_parameters.append(randomized)
 
             return return_parameters

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -686,8 +686,18 @@ def _custom_param_grid_builder(
 
 def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any]]:
     model_parameters = training_config["model_parameters"]
+    model_parameter_search = training_config.get("model_parameter_search")
+
     if "param_grid" in training_config and training_config["param_grid"]:
         model_parameters = _custom_param_grid_builder(model_parameters)
+    elif model_parameter_search is not None:
+        strategy = model_parameter_search["strategy"]
+        if strategy == "explicit":
+            return model_parameters
+        elif strategy == "grid":
+            return _custom_param_grid_builder(model_parameters)
+        else:
+            raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
     elif model_parameters == []:
         raise ValueError(
             "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -67,7 +67,7 @@ class LinkStepTrainTestModels(LinkStep):
 
         splits = self._get_splits(prepped_data, id_a, n_training_iterations, seed)
 
-        model_parameters = self._get_model_parameters(config)
+        model_parameters = _get_model_parameters(training_conf, config)
 
         logger.info(
             f"There are {len(model_parameters)} sets of model parameters to explore; "
@@ -297,18 +297,6 @@ class LinkStepTrainTestModels(LinkStep):
             },
         )
         return pd.concat([results_df, new_results], ignore_index=True)
-
-    def _get_model_parameters(self, conf: dict[str, Any]) -> list[dict[str, Any]]:
-        training_conf = str(self.task.training_conf)
-
-        model_parameters = conf[training_conf]["model_parameters"]
-        if "param_grid" in conf[training_conf] and conf[training_conf]["param_grid"]:
-            model_parameters = _custom_param_grid_builder(model_parameters)
-        elif model_parameters == []:
-            raise ValueError(
-                "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."
-            )
-        return model_parameters
 
     def _save_training_results(
         self, desc_df: pd.DataFrame, spark: pyspark.sql.SparkSession
@@ -694,3 +682,16 @@ def _custom_param_grid_builder(
 
         new_params.extend(params_exploded)
     return new_params
+
+
+def _get_model_parameters(
+    training_conf: str, conf: dict[str, Any]
+) -> list[dict[str, Any]]:
+    model_parameters = conf[training_conf]["model_parameters"]
+    if "param_grid" in conf[training_conf] and conf[training_conf]["param_grid"]:
+        model_parameters = _custom_param_grid_builder(model_parameters)
+    elif model_parameters == []:
+        raise ValueError(
+            "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."
+        )
+    return model_parameters

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -766,17 +766,25 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             rng = random.Random(seed)
 
             return_parameters = []
+            # These keys are special and should not be sampled or modified. All
+            # other keys are hyper-parameters to the model and should be sampled.
+            frozen_keys = {"type", "threshold", "threshold_ratio"}
             for _ in range(num_samples):
                 parameter_spec = rng.choice(model_parameters)
-                model_type = parameter_spec["type"]
-                sample_parameters = dict(
-                    (key, value)
+                sample_parameters = {
+                    key: value
                     for (key, value) in parameter_spec.items()
-                    if key != "type"
-                )
+                    if key not in frozen_keys
+                }
+                frozen_parameters = {
+                    key: value
+                    for (key, value) in parameter_spec.items()
+                    if key in frozen_keys
+                }
+
                 randomized = _choose_randomized_parameters(rng, sample_parameters)
-                randomized["type"] = model_type
-                return_parameters.append(randomized)
+                result = {**frozen_parameters, **randomized}
+                return_parameters.append(result)
 
             return return_parameters
         else:

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -7,6 +7,8 @@ import itertools
 import logging
 import math
 import re
+import sys
+from textwrap import dedent
 from time import perf_counter
 from typing import Any
 import numpy as np
@@ -688,6 +690,21 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
     model_parameters = training_config["model_parameters"]
     model_parameter_search = training_config.get("model_parameter_search")
 
+    if "param_grid" in training_config:
+        print(
+            dedent(
+                """\
+                Deprecation Warning: training.param_grid is deprecated.
+
+                Please use training.model_parameter_search instead by replacing
+
+                `param_grid = True` with `model_parameter_search = {strategy = "grid"}` or
+                `param_grid = False` with `model_parameter_search = {strategy = "explicit"}`
+
+                [deprecated_in_version=4.0.0]"""
+            ),
+            file=sys.stderr,
+        )
     if model_parameter_search is not None:
         strategy = model_parameter_search["strategy"]
         if strategy == "explicit":

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -303,7 +303,7 @@ class LinkStepTrainTestModels(LinkStep):
 
         model_parameters = conf[training_conf]["model_parameters"]
         if "param_grid" in conf[training_conf] and conf[training_conf]["param_grid"]:
-            model_parameters = _custom_param_grid_builder(training_conf, conf)
+            model_parameters = _custom_param_grid_builder(model_parameters)
         elif model_parameters == []:
             raise ValueError(
                 "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."
@@ -665,10 +665,10 @@ def _create_desc_df() -> pd.DataFrame:
 
 
 def _custom_param_grid_builder(
-    training_conf: str, conf: dict[str, Any]
+    model_parameters: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     print("Building param grid for models")
-    given_parameters = conf[training_conf]["model_parameters"]
+    given_parameters = model_parameters
     new_params = []
     for run in given_parameters:
         params = run.copy()

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -67,7 +67,7 @@ class LinkStepTrainTestModels(LinkStep):
 
         splits = self._get_splits(prepped_data, id_a, n_training_iterations, seed)
 
-        model_parameters = _get_model_parameters(training_conf, config)
+        model_parameters = _get_model_parameters(config[training_conf])
 
         logger.info(
             f"There are {len(model_parameters)} sets of model parameters to explore; "
@@ -684,11 +684,9 @@ def _custom_param_grid_builder(
     return new_params
 
 
-def _get_model_parameters(
-    training_conf: str, conf: dict[str, Any]
-) -> list[dict[str, Any]]:
-    model_parameters = conf[training_conf]["model_parameters"]
-    if "param_grid" in conf[training_conf] and conf[training_conf]["param_grid"]:
+def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any]]:
+    model_parameters = training_config["model_parameters"]
+    if "param_grid" in training_config and training_config["param_grid"]:
         model_parameters = _custom_param_grid_builder(model_parameters)
     elif model_parameters == []:
         raise ValueError(

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -6,6 +6,7 @@
 import itertools
 import logging
 import math
+import random
 import re
 import sys
 from textwrap import dedent
@@ -686,6 +687,21 @@ def _custom_param_grid_builder(
     return new_params
 
 
+def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str, Any]:
+    """
+    Choose a randomized setting of parameters from the given specification.
+    """
+    parameter_choices = dict()
+
+    for key, value in model_parameters.items():
+        if key == "type":
+            parameter_choices[key] = value
+        else:
+            parameter_choices[key] = random.choice(value)
+
+    return parameter_choices
+
+
 def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any]]:
     if "param_grid" in training_config:
         print(
@@ -718,6 +734,16 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             return model_parameters
         elif strategy == "grid":
             return _custom_param_grid_builder(model_parameters)
+        elif strategy == "randomized":
+            num_samples = model_parameter_search["num_samples"]
+
+            return_parameters = []
+            for _ in range(num_samples):
+                parameter_spec = random.choice(model_parameters)
+                randomized = _choose_randomized_parameters(parameter_spec)
+                return_parameters.append(randomized)
+
+            return return_parameters
         else:
             raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
     elif use_param_grid:

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -718,7 +718,9 @@ def _choose_randomized_parameters(
                 stdev = value["standard_deviation"]
                 parameter_choices[key] = rng.normalvariate(mean, stdev)
             else:
-                raise ValueError("unknown distribution")
+                raise ValueError(
+                    f"Unknown distribution '{distribution}'. Please choose one of 'randint', 'uniform', or 'normal'."
+                )
         # All other types (including strings) are passed through unchanged.
         else:
             parameter_choices[key] = value

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -696,8 +696,21 @@ def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str,
     for key, value in model_parameters.items():
         if key == "type":
             parameter_choices[key] = value
-        else:
+        elif type(value) == list:
             parameter_choices[key] = random.choice(value)
+        elif type(value) == dict:
+            distribution = value["distribution"]
+            low = value["low"]
+            high = value["high"]
+
+            if distribution == "randint":
+                parameter_choices[key] = random.randint(low, high)
+            elif distribution == "uniform":
+                parameter_choices[key] = random.uniform(low, high)
+            else:
+                raise ValueError("unknown distribution")
+        else:
+            raise ValueError("can't handle value type")
 
     return parameter_choices
 

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -788,7 +788,10 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
 
             return return_parameters
         else:
-            raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
+            raise ValueError(
+                f"Unknown model_parameter_search strategy '{strategy}'. "
+                "Please choose one of 'explicit', 'grid', or 'randomized'."
+            )
     elif use_param_grid:
         return _custom_param_grid_builder(model_parameters)
 

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -695,8 +695,8 @@ def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str,
     parameter_choices = dict()
 
     for key, value in model_parameters.items():
-        # If it's a Sequence (usually list), choose one of the values at random.
-        if isinstance(value, collections.abc.Sequence):
+        # If it's a Sequence (usually list) but not a string, choose one of the values at random.
+        if isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
             parameter_choices[key] = random.choice(value)
         # If it's a Mapping (usually dict), it defines a distribution from which
         # the parameter should be sampled.
@@ -711,8 +711,9 @@ def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str,
                 parameter_choices[key] = random.uniform(low, high)
             else:
                 raise ValueError("unknown distribution")
+        # All other types (including strings) are passed through unchanged.
         else:
-            raise ValueError("can't handle value type")
+            parameter_choices[key] = value
 
     return parameter_choices
 

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -707,6 +707,11 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
     model_parameter_search = training_config.get("model_parameter_search")
     use_param_grid = training_config.get("param_grid", False)
 
+    if model_parameters == []:
+        raise ValueError(
+            "model_parameters is empty, so there are no models to evaluate"
+        )
+
     if model_parameter_search is not None:
         strategy = model_parameter_search["strategy"]
         if strategy == "explicit":
@@ -717,8 +722,5 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
     elif use_param_grid:
         return _custom_param_grid_builder(model_parameters)
-    elif model_parameters == []:
-        raise ValueError(
-            "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."
-        )
+
     return model_parameters

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -688,9 +688,7 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
     model_parameters = training_config["model_parameters"]
     model_parameter_search = training_config.get("model_parameter_search")
 
-    if "param_grid" in training_config and training_config["param_grid"]:
-        model_parameters = _custom_param_grid_builder(model_parameters)
-    elif model_parameter_search is not None:
+    if model_parameter_search is not None:
         strategy = model_parameter_search["strategy"]
         if strategy == "explicit":
             return model_parameters
@@ -698,6 +696,8 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             return _custom_param_grid_builder(model_parameters)
         else:
             raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
+    elif "param_grid" in training_config and training_config["param_grid"]:
+        model_parameters = _custom_param_grid_builder(model_parameters)
     elif model_parameters == []:
         raise ValueError(
             "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -3,6 +3,7 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import collections.abc
 import itertools
 import logging
 import math
@@ -696,9 +697,12 @@ def _choose_randomized_parameters(model_parameters: dict[str, Any]) -> dict[str,
     for key, value in model_parameters.items():
         if key == "type":
             parameter_choices[key] = value
-        elif type(value) == list:
+        # If it's a Sequence (usually list), choose one of the values at random.
+        elif isinstance(value, collections.abc.Sequence):
             parameter_choices[key] = random.choice(value)
-        elif type(value) == dict:
+        # If it's a Mapping (usually dict), it defines a distribution from which
+        # the parameter should be sampled.
+        elif isinstance(value, collections.abc.Mapping):
             distribution = value["distribution"]
             low = value["low"]
             high = value["high"]

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -687,9 +687,6 @@ def _custom_param_grid_builder(
 
 
 def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any]]:
-    model_parameters = training_config["model_parameters"]
-    model_parameter_search = training_config.get("model_parameter_search")
-
     if "param_grid" in training_config:
         print(
             dedent(
@@ -705,6 +702,11 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             ),
             file=sys.stderr,
         )
+
+    model_parameters = training_config["model_parameters"]
+    model_parameter_search = training_config.get("model_parameter_search")
+    use_param_grid = training_config.get("param_grid", False)
+
     if model_parameter_search is not None:
         strategy = model_parameter_search["strategy"]
         if strategy == "explicit":
@@ -713,8 +715,8 @@ def _get_model_parameters(training_config: dict[str, Any]) -> list[dict[str, Any
             return _custom_param_grid_builder(model_parameters)
         else:
             raise ValueError(f"Unknown model_parameter_search strategy '{strategy}'")
-    elif "param_grid" in training_config and training_config["param_grid"]:
-        model_parameters = _custom_param_grid_builder(model_parameters)
+    elif use_param_grid:
+        return _custom_param_grid_builder(model_parameters)
     elif model_parameters == []:
         raise ValueError(
             "No model parameters found. In 'training' config, either supply 'model_parameters' or 'param_grid'."

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -496,6 +496,30 @@ def test_get_model_parameters_search_strategy_randomized_uses_seed(training_conf
     ]
 
 
+def test_get_model_parameters_search_strategy_randomized_unknown_distribution(
+    training_conf,
+):
+    """
+    Passing a distrbution other than "uniform", "randint", or "normal" is an error.
+    """
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "randomized",
+        "num_samples": 10,
+    }
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "decision_tree",
+            "minInfoGain": {"distribution": "laplace", "location": 0.0, "scale": 1.0},
+        }
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown distribution 'laplace'. Please choose one of 'randint', 'uniform', or 'normal'.",
+    ):
+        _get_model_parameters(training_conf["training"])
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -166,10 +166,12 @@ def test_get_model_parameters_default_behavior(training_conf):
     ]
 
 
-def test_get_model_parameters_param_grid_false(training_conf):
+def test_get_model_parameters_param_grid_false(training_conf, capsys):
     """
     When training.param_grid is set to False, model exploration uses the "explicit"
     strategy. The model_parameters are returned unchanged.
+
+    This prints a deprecation warning because param_grid is deprecated.
     """
     training_conf["training"]["model_parameters"] = [
         {"type": "logistic_regression", "threshold": 0.3, "threshold_ratio": 1.4},
@@ -182,11 +184,16 @@ def test_get_model_parameters_param_grid_false(training_conf):
         {"type": "logistic_regression", "threshold": 0.3, "threshold_ratio": 1.4},
     ]
 
+    output = capsys.readouterr()
+    assert "Deprecation Warning: training.param_grid is deprecated" in output.err
 
-def test_get_model_parameters_param_grid_true(training_conf):
+
+def test_get_model_parameters_param_grid_true(training_conf, capsys):
     """
     When training.param_grid is set to True, model exploration uses the "grid"
     strategy, exploding model_parameters.
+
+    This prints a deprecation warning because param_grid is deprecated.
     """
     training_conf["training"]["model_parameters"] = [
         {
@@ -201,6 +208,9 @@ def test_get_model_parameters_param_grid_true(training_conf):
     model_parameters = _get_model_parameters(training_conf["training"])
     # 3 settings for maxDepth * 2 settings for numTrees = 6 total settings
     assert len(model_parameters) == 6
+
+    output = capsys.readouterr()
+    assert "Deprecation Warning: training.param_grid is deprecated" in output.err
 
 
 def test_get_model_parameters_search_strategy_explicit(training_conf):
@@ -249,11 +259,13 @@ def test_get_model_parameters_search_strategy_grid(training_conf):
 
 
 def test_get_model_parameters_search_strategy_explicit_with_param_grid_true(
-    training_conf,
+    training_conf, capsys
 ):
     """
     When both model_parameter_search and param_grid are set, model_parameter_search
     takes precedence.
+
+    This prints a deprecation warning because param_grid is deprecated.
     """
     training_conf["training"]["model_parameters"] = [
         {
@@ -274,11 +286,18 @@ def test_get_model_parameters_search_strategy_explicit_with_param_grid_true(
         {"type": "random_forest", "maxDepth": 10, "numTrees": 75, "threshold": 0.7}
     ]
 
+    output = capsys.readouterr()
+    assert "Deprecation Warning: training.param_grid is deprecated" in output.err
 
-def test_get_model_parameters_search_strategy_grid_with_param_grid_false(training_conf):
+
+def test_get_model_parameters_search_strategy_grid_with_param_grid_false(
+    training_conf, capsys
+):
     """
     When both model_parameter_search and param_grid are set, model_parameter_search
     takes precedence.
+
+    This prints a deprecation warning because param_grid is deprecated.
     """
     training_conf["training"]["model_parameters"] = [
         {
@@ -296,6 +315,9 @@ def test_get_model_parameters_search_strategy_grid_with_param_grid_false(trainin
 
     model_parameters = _get_model_parameters(training_conf["training"])
     assert len(model_parameters) == 6
+
+    output = capsys.readouterr()
+    assert "Deprecation Warning: training.param_grid is deprecated" in output.err
 
 
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -548,6 +548,20 @@ def test_get_model_parameters_search_strategy_randomized_thresholds(training_con
         assert parameter_choice["threshold_ratio"] == 1.2
 
 
+def test_get_model_parameters_unknown_search_strategy(training_conf):
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "something",
+    }
+    training_conf["training"]["model_parameters"] = [{"type": "probit"}]
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown model_parameter_search strategy 'something'. "
+        "Please choose one of 'explicit', 'grid', or 'randomized'.",
+    ):
+        _parameters = _get_model_parameters(training_conf["training"])
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -145,6 +145,17 @@ def test_custom_param_grid_builder():
     assert all(m in expected for m in param_grid)
 
 
+def test_get_model_parameters_error_if_list_empty(training_conf):
+    """
+    It's an error if the model_parameters list is empty, since in that case there
+    aren't any models to evaluate.
+    """
+    training_conf["training"]["model_parameters"] = []
+
+    with pytest.raises(ValueError, match="model_parameters is empty"):
+        _get_model_parameters(training_conf["training"])
+
+
 def test_get_model_parameters_default_behavior(training_conf):
     """
     When there's no training.param_grid attribute or

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -201,6 +201,51 @@ def test_get_model_parameters_param_grid_true(training_conf):
     assert len(model_parameters) == 6
 
 
+def test_get_model_parameters_search_strategy_explicit(training_conf):
+    """
+    When training.model_parameter_search.strategy is set to "explicit",
+    model_parameters pass through unchanged.
+    """
+    training_conf["training"]["model_parameters"] = [
+        {"type": "random_forest", "maxDepth": 15, "numTrees": 100, "threshold": 0.5},
+        {"type": "probit", "threshold": 0.8, "threshold_ratio": 1.3},
+    ]
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "explicit",
+    }
+    assert "param_grid" not in training_conf["training"]
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+
+    assert model_parameters == [
+        {"type": "random_forest", "maxDepth": 15, "numTrees": 100, "threshold": 0.5},
+        {"type": "probit", "threshold": 0.8, "threshold_ratio": 1.3},
+    ]
+
+
+def test_get_model_parameters_search_strategy_grid(training_conf):
+    """
+    When training.model_parameter_search.strategy is set to "grid",
+    model_parameters are exploded.
+    """
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "random_forest",
+            "maxDepth": [5, 10, 15],
+            "numTrees": [50, 100],
+            "threshold": 0.5,
+        },
+    ]
+    training_conf["model_parameter_search"] = {
+        "strategy": "grid",
+    }
+    assert "param_grid" not in training_conf
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+    # 3 settings for maxDepth * 2 settings for numTrees = 6 total settings
+    assert len(model_parameters) == 6
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -156,7 +156,7 @@ def test_get_model_parameters_no_param_grid_attribute(training_conf):
     ]
     assert "param_grid" not in training_conf["training"]
 
-    model_parameters = _get_model_parameters("training", training_conf)
+    model_parameters = _get_model_parameters(training_conf["training"])
 
     assert model_parameters == [
         {"type": "random_forest", "maxDepth": 3, "numTrees": 50},
@@ -174,7 +174,7 @@ def test_get_model_parameters_param_grid_false(training_conf):
     ]
     training_conf["training"]["param_grid"] = False
 
-    model_parameters = _get_model_parameters("training", training_conf)
+    model_parameters = _get_model_parameters(training_conf["training"])
 
     assert model_parameters == [
         {"type": "logistic_regression", "threshold": 0.3, "threshold_ratio": 1.4},
@@ -196,7 +196,7 @@ def test_get_model_parameters_param_grid_true(training_conf):
     ]
     training_conf["training"]["param_grid"] = True
 
-    model_parameters = _get_model_parameters("training", training_conf)
+    model_parameters = _get_model_parameters(training_conf["training"])
     # 3 settings for maxDepth * 2 settings for numTrees = 6 total settings
     assert len(model_parameters) == 6
 

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -397,6 +397,40 @@ def test_get_model_parameters_search_strategy_randomized_sample_from_distributio
         assert 0.0 <= parameter_choice["minInfoGain"] <= 100.0
 
 
+def test_get_model_parameters_search_strategy_randomized_take_values(training_conf):
+    """
+    If a value is neither a list nor a table, the "randomized" strategy just passes
+    it along as a value. This lets the user easily pin some parameters to a particular
+    value and randomize others.
+    """
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "randomized",
+        "num_samples": 25,
+    }
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "random_forest",
+            "maxDepth": 7,
+            "impurity": "entropy",
+            "minInfoGain": 0.5,
+            "numTrees": {"distribution": "randint", "low": 10, "high": 100},
+            "subsamplingRate": [0.5, 1.0, 1.5],
+        }
+    ]
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+
+    assert len(model_parameters) == 25
+
+    for parameter_choice in model_parameters:
+        assert parameter_choice["type"] == "random_forest"
+        assert parameter_choice["maxDepth"] == 7
+        assert parameter_choice["impurity"] == "entropy"
+        assert parameter_choice["minInfoGain"] == 0.5
+        assert 10 <= parameter_choice["numTrees"] <= 100
+        assert parameter_choice["subsamplingRate"] in {0.5, 1.0, 1.5}
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -520,6 +520,34 @@ def test_get_model_parameters_search_strategy_randomized_unknown_distribution(
         _get_model_parameters(training_conf["training"])
 
 
+def test_get_model_parameters_search_strategy_randomized_thresholds(training_conf):
+    """
+    Even when the model parameters are selected with strategy "randomized", the
+    thresholds are still treated with a "grid" strategy.
+    _get_model_parameters() is not in charge of creating the threshold matrix,
+    so it passes the threshold and threshold_ratio through unchanged.
+    """
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "randomized",
+        "num_samples": 25,
+    }
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "random_forest",
+            "maxDepth": [1, 10, 100],
+            "threshold": [0.3, 0.5, 0.7, 0.8, 0.9],
+            "threshold_ratio": 1.2,
+        }
+    ]
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+
+    for parameter_choice in model_parameters:
+        assert parameter_choice["type"] == "random_forest"
+        assert parameter_choice["threshold"] == [0.3, 0.5, 0.7, 0.8, 0.9]
+        assert parameter_choice["threshold_ratio"] == 1.2
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -9,6 +9,7 @@ import pandas as pd
 import hlink.linking.core.threshold as threshold_core
 from hlink.linking.model_exploration.link_step_train_test_models import (
     LinkStepTrainTestModels,
+    _custom_param_grid_builder,
 )
 
 
@@ -121,7 +122,7 @@ def test_all(
     main.do_drop_all("")
 
 
-def test_step_2_param_grid(spark, main, training_conf, model_exploration, fake_self):
+def test_step_2_param_grid(main, training_conf):
     """Test matching step 2 training to see if the custom param grid builder is working"""
 
     training_conf["training"]["model_parameters"] = [
@@ -129,8 +130,7 @@ def test_step_2_param_grid(spark, main, training_conf, model_exploration, fake_s
         {"type": "probit", "threshold": [0.5, 0.7]},
     ]
 
-    link_step = LinkStepTrainTestModels(model_exploration)
-    param_grid = link_step._custom_param_grid_builder(training_conf)
+    param_grid = _custom_param_grid_builder("training", training_conf)
 
     expected = [
         {"maxDepth": 3, "numTrees": 50, "type": "random_forest"},

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -236,7 +236,7 @@ def test_get_model_parameters_search_strategy_grid(training_conf):
             "threshold": 0.5,
         },
     ]
-    training_conf["model_parameter_search"] = {
+    training_conf["training"]["model_parameter_search"] = {
         "strategy": "grid",
     }
     assert "param_grid" not in training_conf

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -331,6 +331,37 @@ def test_get_model_parameters_search_strategy_grid_with_param_grid_false(
     assert "Deprecation Warning: training.param_grid is deprecated" in output.err
 
 
+def test_get_model_parameters_search_strategy_randomized_sample_from_lists(
+    training_conf,
+):
+    """
+    Strategy "randomized" accepts lists for parameter values, but it does not work
+    the same way as the "grid" strategy. It randomly samples values from the lists
+    num_samples times to create parameter combinations.
+    """
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "randomized",
+        "num_samples": 37,
+    }
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "decision_tree",
+            "maxDepth": [1, 5, 10, 20],
+            "maxBins": [10, 20, 40],
+        }
+    ]
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+
+    # Note that if we used strategy grid, we would get a list of length 4 * 3 = 12 instead
+    assert len(model_parameters) == 37
+
+    for parameter_choice in model_parameters:
+        assert parameter_choice["type"] == "decision_tree"
+        assert parameter_choice["maxDepth"] in {1, 5, 10, 20}
+        assert parameter_choice["maxBins"] in {10, 20, 40}
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -362,6 +362,41 @@ def test_get_model_parameters_search_strategy_randomized_sample_from_lists(
         assert parameter_choice["maxBins"] in {10, 20, 40}
 
 
+def test_get_model_parameters_search_strategy_randomized_sample_from_distributions(
+    training_conf,
+):
+    """
+    The "randomized" strategy also accepts dictionary values for parameters.
+    These dictionaries define distributions from which the parameters should be
+    sampled.
+
+    For example, {"distribution": "randint", "low": 1, "high": 20} means to
+    pick a random integer between 1 and 20, each integer with an equal chance.
+    And {"distribution": "uniform", "low": 0.0, "high": 100.0} means to pick a
+    random float between 0.0 and 100.0 with a uniform distribution.
+    """
+    training_conf["training"]["model_parameter_search"] = {
+        "strategy": "randomized",
+        "num_samples": 15,
+    }
+    training_conf["training"]["model_parameters"] = [
+        {
+            "type": "decision_tree",
+            "maxDepth": {"distribution": "randint", "low": 1, "high": 20},
+            "minInfoGain": {"distribution": "uniform", "low": 0.0, "high": 100.0},
+        }
+    ]
+
+    model_parameters = _get_model_parameters(training_conf["training"])
+
+    assert len(model_parameters) == 15
+
+    for parameter_choice in model_parameters:
+        assert parameter_choice["type"] == "decision_tree"
+        assert 1 <= parameter_choice["maxDepth"] <= 20
+        assert 0.0 <= parameter_choice["minInfoGain"] <= 100.0
+
+
 # -------------------------------------
 # Tests that probably should be moved
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -122,15 +122,13 @@ def test_all(
     main.do_drop_all("")
 
 
-def test_step_2_param_grid(main, training_conf):
-    """Test matching step 2 training to see if the custom param grid builder is working"""
-
-    training_conf["training"]["model_parameters"] = [
+def test_custom_param_grid_builder():
+    """Test matching step 2's custom param grid builder"""
+    model_parameters = [
         {"type": "random_forest", "maxDepth": [3, 4, 5], "numTrees": [50, 100]},
         {"type": "probit", "threshold": [0.5, 0.7]},
     ]
-
-    param_grid = _custom_param_grid_builder("training", training_conf)
+    param_grid = _custom_param_grid_builder(model_parameters)
 
     expected = [
         {"maxDepth": 3, "numTrees": 50, "type": "random_forest"},
@@ -144,8 +142,6 @@ def test_step_2_param_grid(main, training_conf):
 
     assert len(param_grid) == len(expected)
     assert all(m in expected for m in param_grid)
-
-    main.do_drop_all("")
 
 
 # -------------------------------------

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -385,6 +385,11 @@ def test_get_model_parameters_search_strategy_randomized_sample_from_distributio
             "type": "decision_tree",
             "maxDepth": {"distribution": "randint", "low": 1, "high": 20},
             "minInfoGain": {"distribution": "uniform", "low": 0.0, "high": 100.0},
+            "minWeightFractionPerNode": {
+                "distribution": "normal",
+                "mean": 10.0,
+                "standard_deviation": 2.5,
+            },
         }
     ]
 
@@ -396,6 +401,10 @@ def test_get_model_parameters_search_strategy_randomized_sample_from_distributio
         assert parameter_choice["type"] == "decision_tree"
         assert 1 <= parameter_choice["maxDepth"] <= 20
         assert 0.0 <= parameter_choice["minInfoGain"] <= 100.0
+        # Technically a normal distribution can return any value, even ones very
+        # far from its mean. So we can't assert on the value returned here. But
+        # there definitely should be a value of some sort in the dictionary.
+        assert "minWeightFractionPerNode" in parameter_choice
 
 
 def test_get_model_parameters_search_strategy_randomized_take_values(training_conf):


### PR DESCRIPTION
This work is for issue #167, which we can close once the v4-dev branch is merged into main and released.

Previously, there were two strategies for searching for the best parameters to a model in model exploration, and the `training.param_grid` config option switched between them. When `param_grid` was false, which was the default, model exploration would take the contents of `training.model_parameters` and test them without any changes or transformation. I've named this strategy "explicit" because the user explicitly writes out each combination of parameters they would like to test. When `param_grid` was true, the user provided lists of possible values for each parameter in `model_parameters`. Then model exploration took this list and generated every possible combination of parameters, testing each combination in serial. This strategy is called a "grid" search because it generates a grid of possible parameter combinations.

This PR adds a third strategy, "randomized" search, which samples each parameter from a list or distribution to create a set number `N` of parameter combinations to test. This differs from grid search, in which every possible combination of parameters becomes a test case. Randomized search should speed up searches for parameters. Grid search may still be helpful in some situations when you need more precision and would like to test a range of values very thoroughly.

To add a third strategy, we have deprecated the `param_grid` option and replaced it with `training.model_parameter_search`. `param_grid` still works but model exploration prints a warning message when you use it. `model_parameter_search` may be

```toml
[training.model_parameter_search]
strategy = "explicit"
```

```toml
[training.model_parameter_search]
strategy = "grid"
```

or

```toml
[training.model_parameter_search]
strategy = "randomized"
num_samples = 50
```

The explicit and grid strategies correspond exactly to the previous behavior with the `param_grid` option. The randomized strategy adds new behavior. When the strategy is randomized, each parameters in `model_parameters` may take one of three different forms.

1. A value, like an integer, string, or float. This parameter is "pinned" in place and is not randomized.
2. A list of values. The value for this parameter will be sampled from the given list at random. Each element has an equal chance of being chosen during each sample. The sampling is with replacement, so the same element may be chosen multiple times.
3. A dictionary which defines a distribution from which the parameter should be sampled. Currently model exploration supports 3 different distributions: "randint", "uniform", and "normal".
    * randint requires "low" and "high" values and returns a random integer in the inclusive range `[low, high]`.
    * uniform requires "low" and "high" values and returns a random float in the inclusive range `[low, high]`.
    * normal requires a "mean" and "standard_deviation" and returns a float sampled from the normal distribution at the given mean and with the given standard deviation.

Here's an example configuration for randomized parameter search.

```toml
[training.model_parameter_search]
strategy = "randomized"
num_samples = 50

[[training.model_parameters]]
type = "random_forest"
# maxDepth is always 7, and impurity is always "entropy"
maxDepth = 7
impurity = "entropy"
# subsamplingRate is sampled from the interval [0.1, 0.9] uniformly
subsamplingRate = {distribution = "uniform", low = 0.1, high = 0.9}
# numTrees is randomly sampled from the list 1, 10, 50, 100
numTrees = [1, 10, 50, 100]
```