### PR TITLE
Allow manually running CI/CD via on: workflow_dispatch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   HLINK_TAG: hlink:githubactions


### PR DESCRIPTION
This is a very small change which should allow running the CI/CD workflow manually via the Actions tab.