### PR TITLE
Run CI/CD on all PRs, not just PRs to main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Colin and I have been working on a v4-dev branch, and we have realized that it would be more convenient if CI/CD automatically ran on all PRs, not just PRs to the main branch. We still run CI/CD on normal commits only if they're on the main branch. And we still allow manual triggers in case you want to check a commit on your branch before creating a PR.