### PR TITLE
Update linking.core.classifier and linking.core.threshold

### DIFF
--- a/hlink/linking/core/classifier.py
+++ b/hlink/linking/core/classifier.py
@@ -61,11 +61,7 @@ def choose_classifier(model_type: str, params: dict[str, Any], dep_var: str):
     features_vector = "features_vector"
     if model_type == "random_forest":
         classifier = RandomForestClassifier(
-            **{
-                key: val
-                for key, val in params.items()
-                if key not in ["threshold", "threshold_ratio"]
-            },
+            **params,
             labelCol=dep_var,
             featuresCol=features_vector,
             seed=2133,
@@ -110,11 +106,7 @@ def choose_classifier(model_type: str, params: dict[str, Any], dep_var: str):
 
     elif model_type == "gradient_boosted_trees":
         classifier = GBTClassifier(
-            **{
-                key: val
-                for key, val in params.items()
-                if key not in ["threshold", "threshold_ratio"]
-            },
+            **params,
             featuresCol=features_vector,
             labelCol=dep_var,
             seed=2133,
@@ -130,13 +122,8 @@ def choose_classifier(model_type: str, params: dict[str, Any], dep_var: str):
                 "its dependencies. Try installing hlink with the lightgbm extra: "
                 "\n\n    pip install hlink[lightgbm]"
             )
-        params_without_threshold = {
-            key: val
-            for key, val in params.items()
-            if key not in {"threshold", "threshold_ratio"}
-        }
         classifier = synapse.ml.lightgbm.LightGBMClassifier(
-            **params_without_threshold,
+            **params,
             featuresCol=features_vector,
             labelCol=dep_var,
             probabilityCol="probability_array",
@@ -151,13 +138,8 @@ def choose_classifier(model_type: str, params: dict[str, Any], dep_var: str):
                 "the xgboost library and its dependencies. Try installing hlink with "
                 "the xgboost extra:\n\n    pip install hlink[xgboost]"
             )
-        params_without_threshold = {
-            key: val
-            for key, val in params.items()
-            if key not in {"threshold", "threshold_ratio"}
-        }
         classifier = xgboost.spark.SparkXGBClassifier(
-            **params_without_threshold,
+            **params,
             features_col=features_vector,
             label_col=dep_var,
             probability_col="probability_array",

--- a/hlink/linking/core/classifier.py
+++ b/hlink/linking/core/classifier.py
@@ -3,6 +3,8 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+from typing import Any
+
 from pyspark.ml.feature import SQLTransformer
 from pyspark.ml.regression import GeneralizedLinearRegression
 from pyspark.ml.classification import (
@@ -28,22 +30,32 @@ else:
     _xgboost_available = True
 
 
-def choose_classifier(model_type, params, dep_var):
-    """Returns a classifier and a post_classification transformer given model type and params.
+def choose_classifier(model_type: str, params: dict[str, Any], dep_var: str):
+    """Given a model type and hyper-parameters for the model, return a
+    classifier of that type with those hyper-parameters, along with a
+    post-classification transformer to run after classification.
+
+    The post-classification transformer standardizes the output of the
+    classifier for further processing. For example, some classifiers create
+    models that output a probability array of [P(dep_var=0), P(dep_var=1)], and
+    the post-classification transformer extracts the single float P(dep_var=1)
+    as the probability for these models.
 
     Parameters
     ----------
-    model_type: string
-        name of model
-    params: dictionary
-        dictionary of parameters for model
-    dep_var: string
-        the dependent variable for the model
+    model_type
+        the type of model, which may be random_forest, probit,
+        logistic_regression, decision_tree, gradient_boosted_trees, lightgbm
+        (requires the 'lightgbm' extra), or xgboost (requires the 'xgboost'
+        extra)
+    params
+        a dictionary of hyper-parameters for the model
+    dep_var
+        the dependent variable for the model, sometimes also called the "label"
 
     Returns
     -------
-    The classifer and a transformer to be used after classification.
-
+    The classifier and a transformer to be used after classification, as a tuple.
     """
     post_transformer = SQLTransformer(statement="SELECT * FROM __THIS__")
     features_vector = "features_vector"

--- a/hlink/linking/core/threshold.py
+++ b/hlink/linking/core/threshold.py
@@ -120,18 +120,13 @@ def _apply_threshold_ratio(
             prob_rank.alias("prob_rank"),
             prob_lead.alias("second_best_prob"),
         )
-        .select(
-            "*",
+        .withColumn(
+            "ratio",
             when(
                 should_compute_probability_ratio,
                 col("probability") / col("second_best_prob"),
-            )
-            .otherwise(None)
-            .alias("ratio"),
+            ).otherwise(None),
         )
-        .select(
-            "*",
-            is_match.cast("integer").alias("prediction"),
-        )
+        .withColumn("prediction", is_match.cast("integer"))
         .drop("prob_rank")
     )

--- a/hlink/linking/core/threshold.py
+++ b/hlink/linking/core/threshold.py
@@ -66,6 +66,11 @@ def predict_using_thresholds(
     -------
     A Spark DataFrame containing the "prediction" column as well as other intermediate columns generated to create the prediction.
     """
+    if "probability" not in pred_df.columns:
+        raise ValueError(
+            "the input data frame must have a 'probability' column to make predictions using thresholds"
+        )
+
     use_threshold_ratio = (
         decision is not None and decision == "drop_duplicate_with_threshold_ratio"
     )
@@ -89,11 +94,6 @@ def _apply_threshold_ratio(
     """Apply a decision threshold using the ration of a match's probability to the next closest match's probability."""
     id_a = id_col + "_a"
     id_b = id_col + "_b"
-    if "probability" not in df.columns:
-        raise NameError(
-            'In order to calculate the threshold ratio based on probabilities, you need to have a "probability" column in your data.'
-        )
-
     windowSpec = Window.partitionBy(id_a).orderBy(col("probability").desc(), id_b)
     prob_rank = rank().over(windowSpec)
     prob_lead = lead("probability", 1).over(windowSpec)

--- a/hlink/linking/core/threshold.py
+++ b/hlink/linking/core/threshold.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pyspark.sql import DataFrame
 from pyspark.sql.window import Window
-from pyspark.sql.functions import rank, lead
+from pyspark.sql.functions import col, lead, rank, when
 
 
 def get_threshold_ratio(
@@ -79,10 +79,8 @@ def predict_using_thresholds(
 
 
 def _apply_alpha_threshold(pred_df: DataFrame, alpha_threshold: float) -> DataFrame:
-    return pred_df.selectExpr(
-        "*",
-        f"CASE WHEN probability >= {alpha_threshold} THEN 1 ELSE 0 END AS prediction",
-    )
+    prediction = when(col("probability") >= alpha_threshold, 1).otherwise(0)
+    return pred_df.withColumn("prediction", prediction)
 
 
 def _apply_threshold_ratio(

--- a/hlink/linking/core/threshold.py
+++ b/hlink/linking/core/threshold.py
@@ -40,8 +40,8 @@ def predict_using_thresholds(
     pred_df: DataFrame,
     alpha_threshold: float,
     threshold_ratio: float,
-    training_conf: dict[str, Any],
     id_col: str,
+    decision: str | None,
 ) -> DataFrame:
     """Adds a prediction column to the given pred_df by applying thresholds.
 
@@ -57,17 +57,17 @@ def predict_using_thresholds(
         to the "a" record's next best probability value.
         Only used with the "drop_duplicate_with_threshold_ratio"
         configuration value.
-    training_conf: dictionary
-        the training config section
     id_col: string
         the id column
+    decision: str | None
+        how to apply the thresholds
 
     Returns
     -------
     A Spark DataFrame containing the "prediction" column as well as other intermediate columns generated to create the prediction.
     """
     use_threshold_ratio = (
-        training_conf.get("decision", "") == "drop_duplicate_with_threshold_ratio"
+        decision is not None and decision == "drop_duplicate_with_threshold_ratio"
     )
 
     if use_threshold_ratio:

--- a/hlink/linking/core/threshold.py
+++ b/hlink/linking/core/threshold.py
@@ -3,11 +3,16 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+from typing import Any
+
+from pyspark.sql import DataFrame
 from pyspark.sql.window import Window
 from pyspark.sql.functions import rank, lead
 
 
-def get_threshold_ratio(training_conf, model_conf, default=1.3):
+def get_threshold_ratio(
+    training_conf: dict[str, Any], model_conf: dict[str, Any], default: float = 1.3
+) -> float | Any:
     """Gets the threshold ratio or default from the config using the correct precedence.
 
     Parameters
@@ -32,8 +37,12 @@ def get_threshold_ratio(training_conf, model_conf, default=1.3):
 
 
 def predict_using_thresholds(
-    pred_df, alpha_threshold, threshold_ratio, training_conf, id_col
-):
+    pred_df: DataFrame,
+    alpha_threshold: float,
+    threshold_ratio: float,
+    training_conf: dict[str, Any],
+    id_col: str,
+) -> DataFrame:
     """Adds a prediction column to the given pred_df by applying thresholds.
 
     Parameters
@@ -69,14 +78,16 @@ def predict_using_thresholds(
         return _apply_alpha_threshold(pred_df.drop("prediction"), alpha_threshold)
 
 
-def _apply_alpha_threshold(pred_df, alpha_threshold):
+def _apply_alpha_threshold(pred_df: DataFrame, alpha_threshold: float) -> DataFrame:
     return pred_df.selectExpr(
         "*",
         f"case when probability >= {alpha_threshold} then 1 else 0 end as prediction",
     )
 
 
-def _apply_threshold_ratio(df, alpha_threshold, threshold_ratio, id_col):
+def _apply_threshold_ratio(
+    df: DataFrame, alpha_threshold: float, threshold_ratio: float, id_col: str
+) -> DataFrame:
     """Apply a decision threshold using the ration of a match's probability to the next closest match's probability."""
     id_a = id_col + "_a"
     id_b = id_col + "_b"

--- a/hlink/linking/matching/link_step_score.py
+++ b/hlink/linking/matching/link_step_score.py
@@ -96,12 +96,13 @@ class LinkStepScore(LinkStep):
         threshold_ratio = threshold_core.get_threshold_ratio(
             config[training_conf], chosen_model_params, default=1.3
         )
+        decision = config[training_conf].get("decision")
         predictions = threshold_core.predict_using_thresholds(
             score_tmp,
             alpha_threshold,
             threshold_ratio,
-            config[training_conf],
             config["id_column"],
+            decision,
         )
         predictions.write.mode("overwrite").saveAsTable(f"{table_prefix}predictions")
         pmp = self.task.spark.table(f"{table_prefix}potential_matches_pipeline")

--- a/hlink/linking/model_exploration/link_step_train_test_models.py
+++ b/hlink/linking/model_exploration/link_step_train_test_models.py
@@ -411,20 +411,21 @@ class LinkStepTrainTestModels(LinkStep):
                 f"{this_alpha_threshold=} and {this_threshold_ratio=}"
             )
             logger.debug(diag)
+            decision = training_settings.get("decision")
             start_predict_time = perf_counter()
             predictions = threshold_core.predict_using_thresholds(
                 thresholding_predictions,
                 this_alpha_threshold,
                 this_threshold_ratio,
-                training_settings,
                 id_column,
+                decision,
             )
             predict_train = threshold_core.predict_using_thresholds(
                 thresholding_predict_train,
                 this_alpha_threshold,
                 this_threshold_ratio,
-                training_settings,
                 id_column,
+                decision,
             )
 
             end_predict_time = perf_counter()

--- a/hlink/tests/core/threshold_test.py
+++ b/hlink/tests/core/threshold_test.py
@@ -26,7 +26,7 @@ def test_predict_using_thresholds_default_decision(spark: SparkSession) -> None:
 
     # We are using the default decision, so threshold_ratio will be ignored
     predictions = predict_using_thresholds(
-        df, alpha_threshold=0.6, threshold_ratio=0.0, training_conf={}, id_col="id"
+        df, alpha_threshold=0.6, threshold_ratio=0.0, id_col="id", decision=None
     )
 
     output_rows = (
@@ -64,13 +64,12 @@ def test_predict_using_thresholds_drop_duplicates_decision(spark: SparkSession) 
         (3, "E", 0.8),
     ]
     df = spark.createDataFrame(input_rows, schema=["id_a", "id_b", "probability"])
-    training_conf = {"decision": "drop_duplicate_with_threshold_ratio"}
     predictions = predict_using_thresholds(
         df,
         alpha_threshold=0.5,
         threshold_ratio=2.0,
-        training_conf=training_conf,
         id_col="id",
+        decision="drop_duplicate_with_threshold_ratio",
     )
 
     output_rows = (

--- a/hlink/tests/core/threshold_test.py
+++ b/hlink/tests/core/threshold_test.py
@@ -1,0 +1,88 @@
+# This file is part of the ISRDI's hlink.
+# For copyright and licensing information, see the NOTICE and LICENSE files
+# in this project's top-level directory, and also on-line at:
+#   https://github.com/ipums/hlink
+
+from pyspark.sql import Row, SparkSession
+
+from hlink.linking.core.threshold import predict_using_thresholds
+
+
+def test_predict_using_thresholds_default_decision(spark: SparkSession) -> None:
+    """
+    The default decision tells predict_using_thresholds() not to do
+    de-duplication on the id. Instead, it just applies alpha_threshold to the
+    probabilities to determine predictions.
+    """
+    input_rows = [
+        (0, "A", 0.1),
+        (0, "B", 0.7),
+        (1, "C", 0.2),
+        (2, "D", 0.4),
+        (3, "E", 1.0),
+        (4, "F", 0.0),
+    ]
+    df = spark.createDataFrame(input_rows, schema=["id_a", "id_b", "probability"])
+
+    # We are using the default decision, so threshold_ratio will be ignored
+    predictions = predict_using_thresholds(
+        df, alpha_threshold=0.6, threshold_ratio=0.0, training_conf={}, id_col="id"
+    )
+
+    output_rows = (
+        predictions.sort("id_a", "id_b").select("id_a", "id_b", "prediction").collect()
+    )
+
+    OutputRow = Row("id_a", "id_b", "prediction")
+    assert output_rows == [
+        OutputRow(0, "A", 0),
+        OutputRow(0, "B", 1),
+        OutputRow(1, "C", 0),
+        OutputRow(2, "D", 0),
+        OutputRow(3, "E", 1),
+        OutputRow(4, "F", 0),
+    ]
+
+
+def test_predict_using_thresholds_drop_duplicates_decision(spark: SparkSession) -> None:
+    """
+    The "drop_duplicates_with_threshold_ratio" decision tells
+    predict_using_thresholds() to look at the ratio between the first- and
+    second-best probabilities for each id, and to only set prediction = 1 when
+    the ratio between those probabilities is at least threshold_ratio.
+    """
+    # id_a 0: two probable matches that will be de-duplicated so that both have prediction = 0
+    # id_a 1: one probable match that will have prediction = 1
+    # id_a 2: one improbable match that will have prediction = 0
+    # id_a 3: one probable match that will have prediction = 1, and one improbable match that will have prediction = 0
+    input_rows = [
+        (0, "A", 0.8),
+        (0, "B", 0.9),
+        (1, "C", 0.75),
+        (2, "C", 0.3),
+        (3, "D", 0.1),
+        (3, "E", 0.8),
+    ]
+    df = spark.createDataFrame(input_rows, schema=["id_a", "id_b", "probability"])
+    training_conf = {"decision": "drop_duplicate_with_threshold_ratio"}
+    predictions = predict_using_thresholds(
+        df,
+        alpha_threshold=0.5,
+        threshold_ratio=2.0,
+        training_conf=training_conf,
+        id_col="id",
+    )
+
+    output_rows = (
+        predictions.sort("id_a", "id_b").select("id_a", "id_b", "prediction").collect()
+    )
+    OutputRow = Row("id_a", "id_b", "prediction")
+
+    assert output_rows == [
+        OutputRow(0, "A", 0),
+        OutputRow(0, "B", 0),
+        OutputRow(1, "C", 1),
+        OutputRow(2, "C", 0),
+        OutputRow(3, "D", 0),
+        OutputRow(3, "E", 1),
+    ]

--- a/hlink/tests/matching_scoring_test.py
+++ b/hlink/tests/matching_scoring_test.py
@@ -51,8 +51,8 @@ def test_step_2_alpha_beta_thresholds(
         score_tmp,
         alpha_threshold,
         threshold_ratio,
-        matching_conf["training"],
         matching_conf["id_column"],
+        matching_conf["training"].get("decision"),
     )
     predictions.write.mode("overwrite").saveAsTable("predictions")
 


### PR DESCRIPTION
These are two core modules which we have been using for our recent work. This PR makes a few updates to both of them, with a couple of breaking changes and some refactoring.

### linking.core.classifier

- `choose_classifier()` no longer filters the `threshold` and `threshold_ratio` keys out of the `params` argument. This was redundant, since we are already filtering these keys out of the hyper-parameters dictionary in the places where we call `choose_classifier()`. It was also confusing because not all of the if branches in the function handled the `params` the same way. Some did filter these keys out, some didn't. Now `choose_classifier()` does not need to know about the config structure, and just accepts a dictionary of hyper-parameters to pass along to the appropriate classifier constructor.

### linking.core.threshold

- Instead of taking the entire `training_conf` as an argument, `predict_using_thresholds()` now takes a `decision` argument. Previously, it extracted `decision` from the training config, then didn't use the training config for anything else. Like `linking.core.classifier.choose_classifier()`, this change makes `predict_using_thresholds()` less coupled to the config structure. Note that the order of arguments has also changed. `decision` appears at the end of the list of arguments, after `id_col`. `training_conf` appeared before `id_col`. This is to support possibly giving `decision` a default value and making it optional in the future.
- Added type hints, documentation, a little bit of logging, and unit tests for linking.core.threshold
- Rewrote some SQL queries in `_apply_alpha_threshold()` and `_apply_threshold_ratio()` as PySpark `Column` expressions. This lets us avoid using Python f-strings to interpolate values from the configuration file (like `alpha_threshold`) into queries, which could change the logic of the query. The PySpark expressions are also more composable and in my opinion a little easier to work with and understand.