### PR TITLE
Model exploration metrics

### DIFF
--- a/hlink/tests/hh_model_exploration_test.py
+++ b/hlink/tests/hh_model_exploration_test.py
@@ -57,10 +57,7 @@ def test_all_hh_mod_ev(
         "precision_test_mean",
         "recall_test_mean",
         "mcc_test_mean",
-        "precision_train_mean",
-        "recall_train_mean",
-        "pr_auc_mean",
-        "mcc_train_mean",
+        "pr_auc_test_mean",
     ]
 
     # TODO we should expect to get most of these columns once the results reporting is finished.
@@ -75,14 +72,8 @@ def test_all_hh_mod_ev(
         "recall_test_sd",
         "mcc_test_sd",
         "mcc_test_mean",
-        "precision_train_mean",
-        "precision_train_sd",
-        "recall_train_mean",
-        "recall_train_sd",
-        "pr_auc_mean",
-        "pr_auc_sd",
-        "mcc_train_mean",
-        "mcc_train_sd",
+        "pr_auc_test_mean",
+        "pr_auc_test_sd",
         "maxDepth",
         "numTrees",
     ]
@@ -97,7 +88,9 @@ def test_all_hh_mod_ev(
     )
     assert tr.query("model == 'logistic_regression'")["alpha_threshold"].iloc[0] == 0.5
     assert (
-        0.7 < tr.query("model == 'logistic_regression'")["pr_auc_mean"].iloc[0] <= 1.0
+        0.7
+        < tr.query("model == 'logistic_regression'")["pr_auc_test_mean"].iloc[0]
+        <= 1.0
     )
     assert (
         0.9
@@ -131,6 +124,8 @@ def test_all_hh_mod_ev(
     assert 0.0 < pm0["second_best_prob"].iloc[0] < 0.5
     """
 
+    # Not saving predict-train test results anymore
+    """
     pred_train = spark.table("hh_model_eval_predict_train").toPandas()
     assert all(
         elem in list(pred_train.columns)
@@ -145,6 +140,7 @@ def test_all_hh_mod_ev(
             "match",
         ]
     )
+    """
 
     # TODO the exact links are different.
     """

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -684,7 +684,6 @@ def test_step_2_train_random_forest_spark(
             "featureSubsetStrategy": "sqrt",
         }
     ]
-    feature_conf["training"]["output_suspicious_TD"] = True
     feature_conf["training"]["n_training_iterations"] = 3
 
     model_exploration.run_step(0)
@@ -694,9 +693,12 @@ def test_step_2_train_random_forest_spark(
     tr = spark.table("model_eval_training_results").toPandas()
     print(f"training results {tr}")
     # assert tr.shape == (1, 18)
-    assert tr.query("model == 'random_forest'")["pr_auc_mean"].iloc[0] > 2.0 / 3.0
+    assert tr.query("model == 'random_forest'")["pr_auc_test_mean"].iloc[0] > 2.0 / 3.0
     assert tr.query("model == 'random_forest'")["maxDepth"].iloc[0] == 3
 
+    # TODO probably remove these since we're not planning to test suspicious data anymore.
+    # I disabled the saving of suspicious in this test config so these are invalid currently.
+    """
     FNs = spark.table("model_eval_repeat_fns").toPandas()
     assert FNs.shape == (3, 4)
     assert FNs.query("id_a == 30")["count"].iloc[0] == 3
@@ -706,6 +708,7 @@ def test_step_2_train_random_forest_spark(
 
     TNs = spark.table("model_eval_repeat_tns").toPandas()
     assert TNs.shape == (6, 4)
+    """
 
     main.do_drop_all("")
 
@@ -717,18 +720,19 @@ def test_step_2_train_logistic_regression_spark(
     feature_conf["training"]["model_parameters"] = [
         {"type": "logistic_regression", "threshold": 0.7}
     ]
-    feature_conf["training"]["n_training_iterations"] = 4
+    feature_conf["training"]["n_training_iterations"] = 3
 
     model_exploration.run_step(0)
     model_exploration.run_step(1)
     model_exploration.run_step(2)
 
     tr = spark.table("model_eval_training_results").toPandas()
+    # assert tr.count == 3
 
     assert tr.shape == (1, 11)
     # This is now 0.83333333333.... I'm not sure it's worth testing against
     # assert tr.query("model == 'logistic_regression'")["pr_auc_mean"].iloc[0] == 0.75
-    assert tr.query("model == 'logistic_regression'")["pr_auc_mean"].iloc[0] > 0.74
+    assert tr.query("model == 'logistic_regression'")["pr_auc_test_mean"].iloc[0] > 0.74
     assert (
         round(tr.query("model == 'logistic_regression'")["alpha_threshold"].iloc[0], 1)
         == 0.7

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -584,7 +584,7 @@ def feature_conf(training_conf):
     training_conf["training"]["independent_vars"] = ["namelast_jw", "regionf"]
 
     training_conf["training"]["model_parameters"] = []
-    training_conf["training"]["n_training_iterations"] = 2
+    training_conf["training"]["n_training_iterations"] = 3
     return training_conf
 
 

--- a/hlink/tests/model_exploration_test.py
+++ b/hlink/tests/model_exploration_test.py
@@ -725,7 +725,7 @@ def test_step_2_train_logistic_regression_spark(
 
     tr = spark.table("model_eval_training_results").toPandas()
 
-    assert tr.shape == (1, 9)
+    assert tr.shape == (1, 11)
     # This is now 0.83333333333.... I'm not sure it's worth testing against
     # assert tr.query("model == 'logistic_regression'")["pr_auc_mean"].iloc[0] == 0.75
     assert tr.query("model == 'logistic_regression'")["pr_auc_mean"].iloc[0] > 0.74
@@ -754,7 +754,7 @@ def test_step_2_train_decision_tree_spark(
     print(f"Decision tree results: {tr}")
 
     # TODO This is  1,12 instead of 1,13, because the precision_test_mean column is dropped as it is NaN
-    assert tr.shape == (1, 12)
+    assert tr.shape == (1, 13)
     # assert tr.query("model == 'decision_tree'")["precision_test_mean"].iloc[0] > 0
     assert tr.query("model == 'decision_tree'")["maxDepth"].iloc[0] == 3
     assert tr.query("model == 'decision_tree'")["minInstancesPerNode"].iloc[0] == 1


### PR DESCRIPTION
Restructures the collection of threshold testing results so we save one row per tested threshold combination. The data in each row is aggregated over the number of inner folds used to test on the thresholds.

There is some special code in the aggregation function to deal with tiny test data cases.

I commented out most code used to save the threshold testing against the training data and saving and testing "suspicious data" that we intend to remove soon. The suspicious data is set to None as a test for this next step, and tests pass.

Some no-longer relevant tests were commented out and some values changed to reflect the new shapes of the final threshold metrics tables in the tests.