### PR TITLE
Use tomli instead of the toml package by default

### DIFF
--- a/hlink/configs/load_config.py
+++ b/hlink/configs/load_config.py
@@ -23,8 +23,18 @@ def load_conf_file(
     name with a '.toml' extension added and load it if it exists. Then do the
     same for a file with a '.json' extension added.
 
+    `use_legacy_toml_parser` tells this function to use the legacy TOML library
+    which hlink used to use instead of the current default. This is provided
+    for backwards compatibility. Some previously written config files may
+    depend on bugs in the legacy TOML library, making it hard to migrate to the
+    new TOML v1.0 compliant parser. It is strongly recommended that new code
+    and config files use the default parser. Old code and config files should
+    also try to migrate to the default parser when possible.
+
     Args:
         conf_name: the file to look for
+        use_legacy_toml_parser: (Not Recommended) Use the legacy, buggy TOML
+        parser instead of the default parser.
 
     Returns:
         a tuple (absolute path to the config file, contents of the config file)
@@ -44,13 +54,10 @@ def load_conf_file(
     for file in existing_files:
         if file.suffix == ".toml":
             # Legacy support for using the "toml" library instead of "tomli".
-            # The toml library currently has a lot of unfixed bugs, and so the tomli
-            # library is more reliable. But some of the bugs in toml may cause config
-            # files to be incompatible with tomli until fixed. So we support using
-            # toml instead of tomli if necessary as a backwards compatibility feature.
             #
-            # Eventually we will remove use_legacy_toml_parser and just use tomli
-            # or Python's standard library tomllib.
+            # Eventually we should remove use_legacy_toml_parser and just use
+            # tomli or Python's standard library tomllib, which is available in
+            # Python 3.11+.
             if use_legacy_toml_parser:
                 with open(file) as f:
                     conf = toml.load(f)

--- a/hlink/tests/config_loader_test.py
+++ b/hlink/tests/config_loader_test.py
@@ -50,3 +50,18 @@ def test_load_conf_file_unrecognized_extension(tmp_path: Path) -> None:
         match="The file .+ exists, but it doesn't have a '.toml' or '.json' extension",
     ):
         load_conf_file(str(conf_file))
+
+
+def test_load_conf_file_json_legacy_parser(conf_dir_path: str) -> None:
+    """
+    The use_legacy_toml_parser argument does not affect json parsing.
+    """
+    conf_file = Path(conf_dir_path) / "test.json"
+    _, conf = load_conf_file(str(conf_file), use_legacy_toml_parser=True)
+    assert conf["id_column"] == "id"
+
+
+def test_load_conf_file_toml_legacy_parser(conf_dir_path: str) -> None:
+    conf_file = Path(conf_dir_path) / "test1.toml"
+    _, conf = load_conf_file(str(conf_file), use_legacy_toml_parser=True)
+    assert conf["id_column"] == "id-toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyspark~=3.5.0",
     "scikit-learn>=1.1.0",
     "toml>=0.10.0",
+    "tomli>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is work for #45 and should close that when this is merged to main.

`configs.load_conf_file()` now uses the `tomli` package instead of `toml` by default. `toml` has some bugs and isn't compliant with TOML v1.0's spec. So swapping to `tomli`, and from there eventually `tomllib` in the standard library, seems to be the way to go. We'll need to be on Python 3.11+ before we can import `tomllib`.

For backwards compatibility, `load_conf_file()` has the `use_legacy_toml_parser` argument. This should help give users (and us at ISRDI!) a longer on-ramp to using the new TOML parser. It's easy to accidentally depend on some bugs in the previous parser in config files.