### PR TITLE
Fix a bug where model_metrics.mcc() < -1.0

### DIFF
--- a/hlink/linking/core/model_metrics.py
+++ b/hlink/linking/core/model_metrics.py
@@ -16,6 +16,16 @@ such as cases with division by zero.
 import math
 
 
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """
+    Clamp the given value, forcing it to be between the minimum and maximum.
+    """
+    if minimum > maximum:
+        raise ValueError("minimum is greater than maximum")
+
+    return max(minimum, min(value, maximum))
+
+
 def f_measure(true_pos: int, false_pos: int, false_neg: int) -> float:
     """
     Compute the F-measure, which is defined as the harmonic mean of precision
@@ -60,7 +70,8 @@ def mcc(true_pos: int, true_neg: int, false_pos: int, false_neg: int) -> float:
         return math.nan
 
     numerator = true_pos * true_neg - false_pos * false_neg
-    return numerator / denominator
+    value = numerator / denominator
+    return clamp(value, minimum=-1.0, maximum=1.0)
 
 
 def precision(true_pos: int, false_pos: int) -> float:


### PR DESCRIPTION
In some rare cases with very large inputs, mcc() could return values outside of the range [-1, 1] due to floating-point precision limitations. To fix this, I've just added a clamp() function and called it to force the return value into the acceptable range.

Closes #187.