### PR TITLE
Remove restriction of scikit-learn < 1.6 for xgboost optional feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,6 @@ lightgbm = [
 xgboost = [
     "xgboost>=2.0",
     "pyarrow>=4.0",
-    # As of 2024-12-10, the latest scikit-learn version (1.6.0) is incompatible
-    # with the latest xgboost version (2.1.3). scikit-learn 1.6.0 came out
-    # yesterday, 2024-12-09, so I'm guessing that this a temporary bug that
-    # will be resolved with an update to one of the two libraries sometime
-    # sooner rather than later. Until then, we can pin scikit-learn to < 1.6
-    # when using xgboost.
-    "scikit-learn<1.6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
When we were first adding XGBoost, there was a compatibility issue between these two libraries at particular versions. The issue's now been been fixed for xgboost >= 2.1.4 and/or scikit-learn 1.6.1. The issue caused a couple of hlink's tests to fail, so it should be pretty easy to confirm that it is working correctly.

See also dmlc/xgboost issue 11093.