### PR TITLE
Require setuptools >= 71

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Check dependency versions
       run: |
         docker run $HLINK_TAG-${{ matrix.python_version}} python -V
+        docker run $HLINK_TAG-${{ matrix.python_version }} pip list
         echo "Java version:"
         docker run $HLINK_TAG-${{ matrix.python_version}} java -version
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=71.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,7 +40,7 @@ dev = [
     # setuptools is only necessary because Python 3.12 removed the distutils
     # package. pyspark 3.5.X still imports this package, so we need it on
     # Python 3.12 to run the tests and have hlink work at all.
-    "setuptools",
+    "setuptools>=71.0",
     # These are pinned so tightly because their version numbers appear in the docs.
     # So if you use a different version, it creates a huge diff in the docs.
     # TODO: auto-generate docs on push to GitHub instead of committing them to the


### PR DESCRIPTION
Closes #197, although the actual fix was in the official Python docker images. They were installing setuptools 65.5.1 and wheel 0.46.1, which are incompatible. It looks like they have pinned wheel < 0.46, and now things are working again. See docker-library/python issue 1023.

This PR upgrades setuptools to version 71 or greater for both the build and runtime dependencies. This should hopefully help prevent incompatibility issues with newer versions of the `wheel` package in the future, although if the Docker images break again by requiring lower versions of setuptools, thne I think that we will be back in the same spot. I've also added `pip list` to the CI/CD check which shows dependency versions, for debugging.