### PR TITLE
Add github workflow to build and publish sphinx docs to github pages

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - action_docs
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,26 +1,49 @@
-name: "Build Sphinx Docs"
+name: Publish Sphinx Docs to GitHub Pages
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install package
+        run: uv sync --extra docs
+      - name: Build docs
+        run: cd "$GITHUB_WORKSPACE/sphinx-docs" && uv run sphinx-build . _build/
+      - name: Upload
+        uses: actions/upload-pages-artifact@v3
         with:
-          persist-credentials: false
-      - name: Build HTML
-        uses: ammaraskar/sphinx-action@0.4
-        with:
-          docs-folder: "sphinx-docs/"
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.ref == 'refs/heads/main'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./sphinx-docs/_build/html
+          path: sphinx-docs/_build/
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - action_docs
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,26 @@
+name: "Build Sphinx Docs"
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build HTML
+        uses: ammaraskar/sphinx-action@0.4
+        with:
+          docs-folder: "sphinx-docs/"
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./sphinx-docs/_build/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,9 @@ dev = [
     "sphinx==8.1.3",
     "recommonmark==0.7.1",
 ]
-lightgbm = [
-    "synapseml>=1.0"
-]
-xgboost = [
-    "xgboost>=2.0",
-    "pyarrow>=4.0",
-]
+docs = ["sphinx", "recommonmark"]
+lightgbm = ["synapseml>=1.0"]
+xgboost = ["xgboost>=2.0", "pyarrow>=4.0"]
 
 [project.scripts]
 hlink = "hlink.scripts.main:cli"

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -32,10 +32,13 @@ release = version
 
 # -- General configuration ---------------------------------------------------
 
+# add CNAME to sphinx docs
+html_baseurl = "hlink.docs.ipums.org"
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["recommonmark", "sphinx.ext.autodoc"]
+extensions = ["recommonmark", "sphinx.ext.autodoc", "sphinx.ext.githubpages"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
I ended up chasing my tail for a lot of this because it seems like much of the established python community prefers to host their docs on readthedocs (which can simply watch your repo and handle the building and deploying on their side).

In the end I landed on the approach of mostly copying how github manages pages builds/deployments for repositories that don't have any actions defined, but inserted a specific sphinx-build (facilitated by uv) in the middle. It seems to work and I've already switched this repo's settings to expect the pages site to be updated via our own actions so once this is merged I think it should just work?

I haven't done it as part of this PR, but assuming everything goes to plan we should be able to delete the /docs/ directory from the top level of this repo as well.