### PR TITLE
Don't create a history file on startup

### DIFF
--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -172,10 +172,12 @@ def _get_spark(run_name: str, args: argparse.Namespace) -> SparkSession:
 
 
 def _read_history_file(history_file):
-    if not os.path.exists(history_file):
-        with open(history_file, "a"):
-            os.utime(history_file, (1330712280, 1330712292))
-    readline.read_history_file(history_file)
+    try:
+        readline.read_history_file(history_file)
+    except FileNotFoundError:
+        # There's no history file, which is fine. Hlink will create a new one
+        # when it shuts down.
+        pass
 
 
 def _cli_loop(spark, args, run_conf, run_name):

--- a/hlink/tests/main_test.py
+++ b/hlink/tests/main_test.py
@@ -1,0 +1,10 @@
+from hlink.scripts.main import _read_history_file
+
+
+def test_read_history_file_does_not_exist(tmp_path) -> None:
+    """
+    _read_history_file() does not raise an exception if the history file does
+    not exist.
+    """
+    history_file = tmp_path / ".history_notthere"
+    _read_history_file(history_file)


### PR DESCRIPTION
This fixes #195.

Instead of manually creating a history file on startup if it doesn't exist, we should catch the FileNotFoundError, then let the readline library create the file normally when hlink shuts down.