### PR TITLE
Update pyproject to switch to new license spec format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=71.0", "setuptools-scm"]
+requires = ["setuptools>=77.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,13 +8,13 @@ version = "4.1.0"
 description = "Fast supervised pyspark record linkage software"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSE.txt" }
+license = "MPL-2.0-no-copyleft-exception"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
 ]
 dependencies = [
     "colorama>=0.4.6",


### PR DESCRIPTION
The setuptools package was printing some warnings about the license format being deprecated when running `python -m build`. I've updated setuptools `>=77.0`, which supports the new format, and I've changed pyproject.toml to follow the new format. I believe I've picked the right SPDX license short string based on LICENSE.txt. Those are listed [here](https://spdx.org/licenses/).