### PR TITLE
Add Spark job descriptions and tweak debug logging

### DIFF
--- a/hlink/linking/hh_matching/link_step_block_on_households.py
+++ b/hlink/linking/hh_matching/link_step_block_on_households.py
@@ -8,6 +8,7 @@ import logging
 from pyspark.sql.functions import col
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 
 logger = logging.getLogger(__name__)
@@ -112,11 +113,13 @@ class LinkStepBlockOnHouseholds(LinkStep):
 
         logger.debug("Blocking on household serial ID and generating potential matches")
         # Generate potential matches with those unmatched people who were in a household with a match, blocking only on household id
-        self.task.run_register_python(
-            "hh_blocked_matches",
-            lambda: stm.join(uma, hhid_a).join(umb, hhid_b).distinct(),
-            persist=True,
-        )
+        spark_context = self.task.spark.sparkContext
+        with set_job_description("create table hh_blocked_matches", spark_context):
+            self.task.run_register_python(
+                "hh_blocked_matches",
+                lambda: stm.join(uma, hhid_a).join(umb, hhid_b).distinct(),
+                persist=True,
+            )
 
         hh_blocked_matches = self.task.spark.table("hh_blocked_matches")
         logger.debug(f"hh_blocked_matches has {hh_blocked_matches.count()} records")

--- a/hlink/linking/hh_matching/link_step_filter.py
+++ b/hlink/linking/hh_matching/link_step_filter.py
@@ -7,6 +7,7 @@ import hlink.linking.core.comparison_feature as comparison_feature_core
 import hlink.linking.core.comparison as comparison_core
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 
 class LinkStepFilter(LinkStep):
@@ -21,6 +22,7 @@ class LinkStepFilter(LinkStep):
     def _run(self):
         # self.task.spark.sql("set spark.sql.shuffle.partitions=4000")
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
 
         # establish empty table context dict to pass to SQL template
         t_ctx = {}
@@ -44,19 +46,25 @@ class LinkStepFilter(LinkStep):
                 if f["alias"] in comp_feature_names
             ]
 
-            self.task.run_register_sql(
-                "hh_potential_matches", t_ctx=t_ctx, persist=True
-            )
+            with set_job_description(
+                "create table hh_potential_matches", spark_context
+            ):
+                self.task.run_register_sql(
+                    "hh_potential_matches", t_ctx=t_ctx, persist=True
+                )
 
         else:
-            self.task.run_register_python(
-                "hh_potential_matches",
-                lambda: self.task.spark.table("hh_blocked_matches"),
-                persist=True,
-            )
+            with set_job_description(
+                "create table hh_potential_matches", spark_context
+            ):
+                self.task.run_register_python(
+                    "hh_potential_matches",
+                    lambda: self.task.spark.table("hh_blocked_matches"),
+                    persist=True,
+                )
 
         self.task.spark.sql("set spark.sql.shuffle.partitions=200")
 
         print(
-            "Potential matches from households which meet hh_comparsions thresholds have been saved to table 'hh_potential_matches'."
+            "Potential matches from households which meet hh_comparisons thresholds have been saved to table 'hh_potential_matches'."
         )

--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -11,6 +11,7 @@ from pyspark.sql.functions import array, explode, col
 
 import hlink.linking.core.comparison as comparison_core
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ class LinkStepExplode(LinkStep):
 
     def _run(self):
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
         # filter the universe of potential matches before exploding
         t_ctx = {}
         universe_conf = config.get("potential_matches_universe", [])
@@ -46,30 +48,32 @@ class LinkStepExplode(LinkStep):
         blocking = config["blocking"]
 
         logger.debug("Creating table exploded_df_a")
-        self.task.run_register_python(
-            name="exploded_df_a",
-            func=lambda: self._explode(
-                df=self.task.spark.table("match_universe_df_a"),
-                comparisons=config["comparisons"],
-                comparison_features=config["comparison_features"],
-                blocking=blocking,
-                id_column=config["id_column"],
-                is_a=True,
-            ),
-        )
+        with set_job_description("create table exploded_df_a", spark_context):
+            self.task.run_register_python(
+                name="exploded_df_a",
+                func=lambda: self._explode(
+                    df=self.task.spark.table("match_universe_df_a"),
+                    comparisons=config["comparisons"],
+                    comparison_features=config["comparison_features"],
+                    blocking=blocking,
+                    id_column=config["id_column"],
+                    is_a=True,
+                ),
+            )
 
         logger.debug("Creating table exploded_df_b")
-        self.task.run_register_python(
-            name="exploded_df_b",
-            func=lambda: self._explode(
-                df=self.task.spark.table("match_universe_df_b"),
-                comparisons=config["comparisons"],
-                comparison_features=config["comparison_features"],
-                blocking=blocking,
-                id_column=config["id_column"],
-                is_a=False,
-            ),
-        )
+        with set_job_description("create table exploded_df_b", spark_context):
+            self.task.run_register_python(
+                name="exploded_df_b",
+                func=lambda: self._explode(
+                    df=self.task.spark.table("match_universe_df_b"),
+                    comparisons=config["comparisons"],
+                    comparison_features=config["comparison_features"],
+                    blocking=blocking,
+                    id_column=config["id_column"],
+                    is_a=False,
+                ),
+            )
 
     def _explode(
         self,

--- a/hlink/linking/matching/link_step_explode.py
+++ b/hlink/linking/matching/link_step_explode.py
@@ -3,6 +3,7 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/hlink
 
+import logging
 from typing import Any
 
 from pyspark.sql import Column, DataFrame
@@ -10,6 +11,8 @@ from pyspark.sql.functions import array, explode, col
 
 import hlink.linking.core.comparison as comparison_core
 from hlink.linking.link_step import LinkStep
+
+logger = logging.getLogger(__name__)
 
 
 class LinkStepExplode(LinkStep):
@@ -42,6 +45,7 @@ class LinkStepExplode(LinkStep):
         # self.spark.sql("set spark.sql.shuffle.partitions=4000")
         blocking = config["blocking"]
 
+        logger.debug("Creating table exploded_df_a")
         self.task.run_register_python(
             name="exploded_df_a",
             func=lambda: self._explode(
@@ -53,6 +57,8 @@ class LinkStepExplode(LinkStep):
                 is_a=True,
             ),
         )
+
+        logger.debug("Creating table exploded_df_b")
         self.task.run_register_python(
             name="exploded_df_b",
             func=lambda: self._explode(
@@ -118,6 +124,7 @@ class LinkStepExplode(LinkStep):
 
         all_exploding_columns = [bc for bc in blocking if bc.get("explode", False)]
 
+        logger.debug(f"Exploding {len(all_exploding_columns)} column(s)")
         for exploding_column in all_exploding_columns:
             exploding_column_name = exploding_column["column_name"]
             if exploding_column.get("expand_length", False):

--- a/hlink/linking/matching/link_step_match.py
+++ b/hlink/linking/matching/link_step_match.py
@@ -10,7 +10,7 @@ from typing import Any
 import hlink.linking.core.comparison_feature as comparison_feature_core
 import hlink.linking.core.dist_table as dist_table_core
 import hlink.linking.core.comparison as comparison_core
-from hlink.linking.util import spark_shuffle_partitions_heuristic
+from hlink.linking.util import set_job_description, spark_shuffle_partitions_heuristic
 
 from hlink.linking.link_step import LinkStep
 
@@ -149,8 +149,13 @@ class LinkStepMatch(LinkStep):
 
         if config.get("streamline_potential_match_generation", False):
             t_ctx["dataset_columns"] = [config["id_column"]]
+
+        spark_context = self.task.spark.sparkContext
+        logger.debug("Creating table potential_matches via potential_matches.sql")
         try:
-            logger.debug("Creating table potential_matches via potential_matches.sql")
-            self.task.run_register_sql("potential_matches", t_ctx=t_ctx, persist=True)
+            with set_job_description("create table potential_matches", spark_context):
+                self.task.run_register_sql(
+                    "potential_matches", t_ctx=t_ctx, persist=True
+                )
         finally:
             self.task.spark.sql("set spark.sql.shuffle.partitions=200")

--- a/hlink/linking/matching/link_step_match.py
+++ b/hlink/linking/matching/link_step_match.py
@@ -150,6 +150,7 @@ class LinkStepMatch(LinkStep):
         if config.get("streamline_potential_match_generation", False):
             t_ctx["dataset_columns"] = [config["id_column"]]
         try:
+            logger.debug("Creating table potential_matches via potential_matches.sql")
             self.task.run_register_sql("potential_matches", t_ctx=t_ctx, persist=True)
         finally:
             self.task.spark.sql("set spark.sql.shuffle.partitions=200")

--- a/hlink/linking/matching/link_step_score.py
+++ b/hlink/linking/matching/link_step_score.py
@@ -10,7 +10,7 @@ from pyspark.sql import functions as f
 import hlink.linking.core.comparison_feature as comparison_feature_core
 import hlink.linking.core.threshold as threshold_core
 import hlink.linking.core.dist_table as dist_table_core
-from hlink.linking.util import spark_shuffle_partitions_heuristic
+from hlink.linking.util import set_job_description, spark_shuffle_partitions_heuristic
 
 from hlink.linking.link_step import LinkStep
 
@@ -35,6 +35,7 @@ class LinkStepScore(LinkStep):
         training_conf = str(self.task.training_conf)
         table_prefix = self.task.table_prefix
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
 
         if training_conf not in config or "chosen_model" not in config[training_conf]:
             print(
@@ -52,7 +53,8 @@ class LinkStepScore(LinkStep):
         id_a = config["id_column"] + "_a"
         id_b = config["id_column"] + "_b"
         chosen_model_params = config[training_conf]["chosen_model"].copy()
-        self._create_features(config)
+        with set_job_description("create comparison features", spark_context):
+            self._create_features(config)
         pm = self.task.spark.table(f"{table_prefix}potential_matches_prepped")
 
         ind_var_columns = config[training_conf]["independent_vars"]
@@ -81,11 +83,12 @@ class LinkStepScore(LinkStep):
             )
 
         logger.debug(f"Creating table {table_prefix}potential_matches_pipeline")
-        self.task.run_register_python(
-            f"{table_prefix}potential_matches_pipeline",
-            lambda: pre_pipeline.transform(pm.select(*required_columns)),
-            persist=True,
-        )
+        with set_job_description("prepare the data for the model", spark_context):
+            self.task.run_register_python(
+                f"{table_prefix}potential_matches_pipeline",
+                lambda: pre_pipeline.transform(pm.select(*required_columns)),
+                persist=True,
+            )
         plm = self.task.link_run.trained_models[f"{table_prefix}trained_model"]
         pp_required_cols = set(plm.stages[0].getInputCols() + [id_a, id_b])
         pre_pipeline = self.task.spark.table(
@@ -106,14 +109,26 @@ class LinkStepScore(LinkStep):
             config["id_column"],
             decision,
         )
-        predictions.write.mode("overwrite").saveAsTable(f"{table_prefix}predictions")
+
+        with set_job_description(
+            f"create table {table_prefix}predictions", spark_context
+        ):
+            predictions.write.mode("overwrite").saveAsTable(
+                f"{table_prefix}predictions"
+            )
         pmp = self.task.spark.table(f"{table_prefix}potential_matches_pipeline")
         logger.debug(f"Creating table {table_prefix}scored_potential_matches")
-        self._save_table_with_requested_columns(pm, pmp, predictions, id_a, id_b)
+        with set_job_description(
+            f"create table {table_prefix}scored_potential_matches", spark_context
+        ):
+            self._save_table_with_requested_columns(pm, pmp, predictions, id_a, id_b)
         logger.debug(
             f"Creating table {table_prefix}predicted_matches and removing records with duplicated id_b"
         )
-        self._save_predicted_matches(config, id_a, id_b)
+        with set_job_description(
+            f"create table {table_prefix}predicted_matches", spark_context
+        ):
+            self._save_predicted_matches(config, id_a, id_b)
         self.task.spark.sql("set spark.sql.shuffle.partitions=200")
 
     def _save_table_with_requested_columns(self, pm, pmp, predictions, id_a, id_b):

--- a/hlink/linking/matching/link_step_score.py
+++ b/hlink/linking/matching/link_step_score.py
@@ -80,6 +80,7 @@ class LinkStepScore(LinkStep):
                 "Missing a temporary table from the training task. This table will not be persisted between sessions of hlink for technical reasons. Please run training before running this step."
             )
 
+        logger.debug(f"Creating table {table_prefix}potential_matches_pipeline")
         self.task.run_register_python(
             f"{table_prefix}potential_matches_pipeline",
             lambda: pre_pipeline.transform(pm.select(*required_columns)),
@@ -97,6 +98,7 @@ class LinkStepScore(LinkStep):
             config[training_conf], chosen_model_params, default=1.3
         )
         decision = config[training_conf].get("decision")
+        logger.debug("Predicting with thresholds")
         predictions = threshold_core.predict_using_thresholds(
             score_tmp,
             alpha_threshold,
@@ -106,7 +108,11 @@ class LinkStepScore(LinkStep):
         )
         predictions.write.mode("overwrite").saveAsTable(f"{table_prefix}predictions")
         pmp = self.task.spark.table(f"{table_prefix}potential_matches_pipeline")
+        logger.debug(f"Creating table {table_prefix}scored_potential_matches")
         self._save_table_with_requested_columns(pm, pmp, predictions, id_a, id_b)
+        logger.debug(
+            f"Creating table {table_prefix}predicted_matches and removing records with duplicated id_b"
+        )
         self._save_predicted_matches(config, id_a, id_b)
         self.task.spark.sql("set spark.sql.shuffle.partitions=200")
 
@@ -174,6 +180,7 @@ class LinkStepScore(LinkStep):
         potential_matches = f"{table_prefix}potential_matches"
         table_name = f"{table_prefix}potential_matches_prepped"
         pm_columns = self.task.spark.table(potential_matches).columns
+        logger.debug("Getting comparison features")
         (
             comp_features,
             advanced_comp_features,
@@ -200,6 +207,7 @@ class LinkStepScore(LinkStep):
                 dist_tables
             )
 
+        logger.debug("Creating all of the comparison features")
         comparison_feature_core.create_feature_tables(
             self.task,
             t_ctx_def,

--- a/hlink/linking/preprocessing/link_step_prep_dataframes.py
+++ b/hlink/linking/preprocessing/link_step_prep_dataframes.py
@@ -40,6 +40,7 @@ class LinkStepPrepDataframes(LinkStep):
         substitution_columns = config.get("substitution_columns", [])
         feature_selections = config.get("feature_selections", [])
 
+        logger.debug("Creating table prepped_df_a")
         self.task.run_register_python(
             name="prepped_df_a",
             func=lambda: self._prep_dataframe(
@@ -52,6 +53,8 @@ class LinkStepPrepDataframes(LinkStep):
             ),
             persist=True,
         )
+
+        logger.debug("Creating table prepped_df_b")
         self.task.run_register_python(
             name="prepped_df_b",
             func=lambda: self._prep_dataframe(
@@ -97,6 +100,7 @@ class LinkStepPrepDataframes(LinkStep):
         column_selects = [col(id_column)]
         custom_transforms = self.task.link_run.custom_column_mapping_transforms
 
+        logger.debug("Selecting column mappings")
         for column_mapping in column_definitions:
             df_selected, column_selects = column_mapping_core.select_column_mapping(
                 column_mapping,
@@ -108,10 +112,12 @@ class LinkStepPrepDataframes(LinkStep):
 
         df_selected = df_selected.select(column_selects)
 
+        logger.debug("Generating substitutions")
         df_selected = substitutions_core.generate_substitutions(
             spark, df_selected, substitution_columns
         )
 
+        logger.debug("Generating transforms")
         df_selected = transforms_core.generate_transforms(
             spark, df_selected, feature_selections, self.task, is_a, id_column
         )

--- a/hlink/linking/preprocessing/link_step_prep_dataframes.py
+++ b/hlink/linking/preprocessing/link_step_prep_dataframes.py
@@ -9,7 +9,7 @@ from pyspark.sql.functions import col
 import hlink.linking.core.column_mapping as column_mapping_core
 import hlink.linking.core.substitutions as substitutions_core
 import hlink.linking.core.transforms as transforms_core
-from hlink.linking.util import spark_shuffle_partitions_heuristic
+from hlink.linking.util import set_job_description, spark_shuffle_partitions_heuristic
 
 from hlink.linking.link_step import LinkStep
 
@@ -27,6 +27,7 @@ class LinkStepPrepDataframes(LinkStep):
 
     def _run(self):
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
 
         dataset_size_a = self.task.spark.table("raw_df_a").count()
         dataset_size_b = self.task.spark.table("raw_df_b").count()
@@ -41,32 +42,34 @@ class LinkStepPrepDataframes(LinkStep):
         feature_selections = config.get("feature_selections", [])
 
         logger.debug("Creating table prepped_df_a")
-        self.task.run_register_python(
-            name="prepped_df_a",
-            func=lambda: self._prep_dataframe(
-                self.task.spark.table("raw_df_a"),
-                config["column_mappings"],
-                substitution_columns,
-                feature_selections,
-                True,
-                config["id_column"],
-            ),
-            persist=True,
-        )
+        with set_job_description("create table prepped_df_a", spark_context):
+            self.task.run_register_python(
+                name="prepped_df_a",
+                func=lambda: self._prep_dataframe(
+                    self.task.spark.table("raw_df_a"),
+                    config["column_mappings"],
+                    substitution_columns,
+                    feature_selections,
+                    True,
+                    config["id_column"],
+                ),
+                persist=True,
+            )
 
         logger.debug("Creating table prepped_df_b")
-        self.task.run_register_python(
-            name="prepped_df_b",
-            func=lambda: self._prep_dataframe(
-                self.task.spark.table("raw_df_b"),
-                config["column_mappings"],
-                substitution_columns,
-                feature_selections,
-                False,
-                config["id_column"],
-            ),
-            persist=True,
-        )
+        with set_job_description("create table prepped_df_b", spark_context):
+            self.task.run_register_python(
+                name="prepped_df_b",
+                func=lambda: self._prep_dataframe(
+                    self.task.spark.table("raw_df_b"),
+                    config["column_mappings"],
+                    substitution_columns,
+                    feature_selections,
+                    False,
+                    config["id_column"],
+                ),
+                persist=True,
+            )
 
         self.task.spark.sql("set spark.sql.shuffle.partitions=200")
 

--- a/hlink/linking/preprocessing/link_step_register_raw_dfs.py
+++ b/hlink/linking/preprocessing/link_step_register_raw_dfs.py
@@ -73,11 +73,14 @@ class LinkStepRegisterRawDfs(LinkStep):
         else:
             df_b = df_b_filtered
 
+        logger.debug("Creating table raw_df_a")
         self.task.run_register_python(
             name="raw_df_a",
             func=lambda: df_a,
             persist=True,
         )
+
+        logger.debug("Creating table raw_df_b")
         self.task.run_register_python(
             name="raw_df_b",
             func=lambda: df_b,

--- a/hlink/linking/preprocessing/link_step_register_raw_dfs.py
+++ b/hlink/linking/preprocessing/link_step_register_raw_dfs.py
@@ -11,6 +11,7 @@ from pyspark.sql.functions import col
 
 from hlink.errors import DataError
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 logger = logging.getLogger(__name__)
 
@@ -48,14 +49,19 @@ class LinkStepRegisterRawDfs(LinkStep):
 
     def _run(self):
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
         path_a, file_type_a = handle_paths(config["datasource_a"], "a")
         path_b, file_type_b = handle_paths(config["datasource_b"], "b")
 
-        self._load_unpartitioned(file_type_a, "_a", path_a)
-        self._load_unpartitioned(file_type_b, "_b", path_b)
+        with set_job_description("load data source A", spark_context):
+            self._load_unpartitioned(file_type_a, "_a", path_a)
+        with set_job_description("load data source B", spark_context):
+            self._load_unpartitioned(file_type_b, "_b", path_b)
 
-        df_a_filtered = self._filter_dataframe(config, "a")
-        df_b_filtered = self._filter_dataframe(config, "b")
+        with set_job_description("filter data source A", spark_context):
+            df_a_filtered = self._filter_dataframe(config, "a")
+        with set_job_description("filter data source B", spark_context):
+            df_b_filtered = self._filter_dataframe(config, "b")
 
         if config["datasource_a"].get("convert_ints_to_longs", False):
             logger.debug(
@@ -74,18 +80,20 @@ class LinkStepRegisterRawDfs(LinkStep):
             df_b = df_b_filtered
 
         logger.debug("Creating table raw_df_a")
-        self.task.run_register_python(
-            name="raw_df_a",
-            func=lambda: df_a,
-            persist=True,
-        )
+        with set_job_description("create table raw_df_a", spark_context):
+            self.task.run_register_python(
+                name="raw_df_a",
+                func=lambda: df_a,
+                persist=True,
+            )
 
         logger.debug("Creating table raw_df_b")
-        self.task.run_register_python(
-            name="raw_df_b",
-            func=lambda: df_b,
-            persist=True,
-        )
+        with set_job_description("create table raw_df_b", spark_context):
+            self.task.run_register_python(
+                name="raw_df_b",
+                func=lambda: df_b,
+                persist=True,
+            )
 
         self._check_for_all_spaces_unrestricted_file("raw_df_a")
         self._check_for_all_spaces_unrestricted_file("raw_df_b")

--- a/hlink/linking/training/link_step_create_comparison_features.py
+++ b/hlink/linking/training/link_step_create_comparison_features.py
@@ -7,6 +7,7 @@ import hlink.linking.core.comparison_feature as comparison_feature_core
 import hlink.linking.core.dist_table as dist_table_core
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 
 class LinkStepCreateComparisonFeatures(LinkStep):
@@ -86,11 +87,13 @@ class LinkStepCreateComparisonFeatures(LinkStep):
                 dist_tables
             )
 
-        comparison_feature_core.create_feature_tables(
-            self.task,
-            t_ctx_def,
-            advanced_comp_features,
-            hh_comp_features,
-            config["id_column"],
-            table_name=f"{table_prefix}training_features",
-        )
+        spark_context = self.task.spark.sparkContext
+        with set_job_description("create comparison features", spark_context):
+            comparison_feature_core.create_feature_tables(
+                self.task,
+                t_ctx_def,
+                advanced_comp_features,
+                hh_comp_features,
+                config["id_column"],
+                table_name=f"{table_prefix}training_features",
+            )

--- a/hlink/linking/training/link_step_ingest_file.py
+++ b/hlink/linking/training/link_step_ingest_file.py
@@ -4,6 +4,7 @@
 #   https://github.com/ipums/hlink
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 
 class LinkStepIngestFile(LinkStep):
@@ -16,12 +17,15 @@ class LinkStepIngestFile(LinkStep):
         )
 
     def _run(self):
-        self.task.run_register_python(
-            f"{self.task.table_prefix}training_data",
-            lambda: self.task.spark.read.csv(
-                self.task.link_run.config[f"{self.task.training_conf}"]["dataset"],
-                header=True,
-                inferSchema=True,
-            ),
-            persist=True,
-        )
+        spark_context = self.task.spark.sparkContext
+
+        with set_job_description("load training data", spark_context):
+            self.task.run_register_python(
+                f"{self.task.table_prefix}training_data",
+                lambda: self.task.spark.read.csv(
+                    self.task.link_run.config[f"{self.task.training_conf}"]["dataset"],
+                    header=True,
+                    inferSchema=True,
+                ),
+                persist=True,
+            )

--- a/hlink/linking/training/link_step_save_model_metadata.py
+++ b/hlink/linking/training/link_step_save_model_metadata.py
@@ -14,6 +14,7 @@ from pyspark.sql.types import (
 )
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,9 @@ class LinkStepSaveModelMetadata(LinkStep):
         feature_importances_table = (
             f"{self.task.table_prefix}training_feature_importances"
         )
-        features_df.write.mode("overwrite").saveAsTable(feature_importances_table)
+
+        spark_context = self.task.spark.sparkContext
+        with set_job_description("save training feature importances", spark_context):
+            features_df.write.mode("overwrite").saveAsTable(feature_importances_table)
 
         print(f"{label} have been saved to the {feature_importances_table} table")

--- a/hlink/linking/training/link_step_save_model_metadata.py
+++ b/hlink/linking/training/link_step_save_model_metadata.py
@@ -107,7 +107,6 @@ class LinkStepSaveModelMetadata(LinkStep):
 
         model_type = config[training_conf]["chosen_model"]["type"]
 
-        logger.debug(f"Expanded features with categories are {expanded_features}")
         logger.debug(f"The model type is '{model_type}'")
 
         print("Retrieving model feature importances or coefficients...")
@@ -169,7 +168,6 @@ class LinkStepSaveModelMetadata(LinkStep):
                 ),
             ]
 
-        logger.debug("Creating the DataFrame and saving it as a table")
         feature_names, categories = zip(*expanded_features)
         importance_schema, importance_data = zip(*importance_columns)
         features_df = self.task.spark.createDataFrame(

--- a/hlink/linking/training/link_step_train_and_save_model.py
+++ b/hlink/linking/training/link_step_train_and_save_model.py
@@ -10,6 +10,7 @@ import hlink.linking.core.pipeline as pipeline_core
 import hlink.linking.core.threshold as threshold_core
 
 from hlink.linking.link_step import LinkStep
+from hlink.linking.util import set_job_description
 
 
 class LinkStepTrainAndSaveModel(LinkStep):
@@ -26,6 +27,7 @@ class LinkStepTrainAndSaveModel(LinkStep):
         training_conf = str(self.task.training_conf)
         table_prefix = self.task.table_prefix
         config = self.task.link_run.config
+        spark_context = self.task.spark.sparkContext
 
         if not config[training_conf].get("score_with_model", False):
             raise ValueError(
@@ -58,11 +60,15 @@ class LinkStepTrainAndSaveModel(LinkStep):
 
         pre_pipeline = Pipeline(stages=pipeline_stages[:-1]).fit(tf)
         self.task.link_run.trained_models[f"{table_prefix}pre_pipeline"] = pre_pipeline
-        tf_prepped = pre_pipeline.transform(tf)
 
-        tf_prepped.write.mode("overwrite").saveAsTable(
-            f"{table_prefix}training_features_prepped"
-        )
+        with set_job_description(
+            "prepare the training data for the model", spark_context
+        ):
+            tf_prepped = pre_pipeline.transform(tf)
+
+            tf_prepped.write.mode("overwrite").saveAsTable(
+                f"{table_prefix}training_features_prepped"
+            )
 
         classifier, post_transformer = classifier_core.choose_classifier(
             chosen_model_type, chosen_model_params, dep_var
@@ -71,7 +77,8 @@ class LinkStepTrainAndSaveModel(LinkStep):
         # Train and save pipeline
         pipeline = Pipeline(stages=[vector_assembler, classifier, post_transformer])
 
-        model = pipeline.fit(tf_prepped)
+        with set_job_description("train the model", spark_context):
+            model = pipeline.fit(tf_prepped)
         # model_path = config["spark_tmp_dir"] + "/chosen_model"
         self.task.link_run.trained_models[f"{table_prefix}trained_model"] = model
         # model.write().overwrite().save(model_path)

--- a/hlink/linking/transformers/rename_vector_attributes.py
+++ b/hlink/linking/transformers/rename_vector_attributes.py
@@ -69,11 +69,6 @@ class RenameVectorAttributes(Transformer, HasInputCol):
         replacement_str = self.getOrDefault("replaceWith")
         metadata = dataset.schema[input_col].metadata
 
-        logger.debug(
-            f"Renaming the attributes of vector column '{input_col}': "
-            f"replacing {to_replace} with '{replacement_str}'"
-        )
-
         if "attrs" in metadata["ml_attr"]:
             attributes_by_type = metadata["ml_attr"]["attrs"]
 

--- a/hlink/linking/util.py
+++ b/hlink/linking/util.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from math import ceil
 
 
@@ -16,3 +17,13 @@ def spark_shuffle_partitions_heuristic(dataset_size: int) -> int:
     clamped_below = max(MIN_PARTITIONS, partitions_approx)
     clamped = min(MAX_PARTITIONS, clamped_below)
     return clamped
+
+
+@contextmanager
+def set_job_description(desc: str | None, spark_context):
+    previous_desc = spark_context.getLocalProperty("spark.job.description")
+    spark_context.setJobDescription(desc)
+    try:
+        yield
+    finally:
+        spark_context.setJobDescription(previous_desc)

--- a/hlink/linking/util.py
+++ b/hlink/linking/util.py
@@ -21,6 +21,12 @@ def spark_shuffle_partitions_heuristic(dataset_size: int) -> int:
 
 @contextmanager
 def set_job_description(desc: str | None, spark_context):
+    """Set the Spark job description.
+
+    This context manager sets the Spark job description to the given string,
+    then restores the job description to its previous value on exit. Passing
+    desc=None resets the job description to the Spark default.
+    """
     previous_desc = spark_context.getLocalProperty("spark.job.description")
     spark_context.setJobDescription(desc)
     try:

--- a/hlink/scripts/main.py
+++ b/hlink/scripts/main.py
@@ -223,6 +223,7 @@ def _setup_logging(conf_path, run_name):
     print(f"*** Hlink log: {log_file.absolute()}")
 
     logging.basicConfig(filename=log_file, level=logging.INFO, format=format_string)
+    logging.getLogger("hlink").setLevel(logging.DEBUG)
 
     logger.info(f"New session {session_id} by user {user}")
     logger.info(f"Configured with {conf_path}")

--- a/hlink/tests/linking_util_test.py
+++ b/hlink/tests/linking_util_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hlink.linking.util import spark_shuffle_partitions_heuristic
+from hlink.linking.util import set_job_description, spark_shuffle_partitions_heuristic
 
 
 @pytest.mark.parametrize(
@@ -10,3 +10,30 @@ from hlink.linking.util import spark_shuffle_partitions_heuristic
 def test_spark_shuffle_partitions_heuristic(dataset_size, expected_output):
     output = spark_shuffle_partitions_heuristic(dataset_size)
     assert output == expected_output
+
+
+def test_set_job_description(spark):
+    with set_job_description("my description", spark.sparkContext):
+        desc = spark.sparkContext.getLocalProperty("spark.job.description")
+        assert desc == "my description"
+
+
+def test_set_job_description_resets_on_error(spark):
+    spark.sparkContext.setJobDescription(None)
+
+    try:
+        with set_job_description("my description", spark.sparkContext):
+            raise Exception()
+    except Exception:
+        ...
+
+    assert spark.sparkContext.getLocalProperty("spark.job.description") is None
+
+
+def test_set_job_description_nested(spark):
+    with set_job_description("outer description", spark.sparkContext):
+        with set_job_description("inner description", spark.sparkContext):
+            desc = spark.sparkContext.getLocalProperty("spark.job.description")
+            assert desc == "inner description"
+        desc = spark.sparkContext.getLocalProperty("spark.job.description")
+        assert desc == "outer description"

--- a/sphinx-docs/changelog.md
+++ b/sphinx-docs/changelog.md
@@ -3,6 +3,14 @@
 The format of this changelog is based on [Keep A Changelog][keep-a-changelog].
 Hlink adheres to semantic versioning as much as possible.
 
+## Not Yet Released
+
+### Added
+
+* Started setting custom Spark job descriptions for some of hlink's long-running
+  jobs. These descriptions appear in the Spark UI and make it easier to understand
+  what hlink is doing. [PR #228][pr228]
+
 ## v4.2.1 (2025-08-18)
 
 ### Fixed
@@ -453,6 +461,7 @@ and false negative data in model exploration. [PR #1][pr1]
 [pr215]: https://github.com/ipums/hlink/pull/215
 [pr219]: https://github.com/ipums/hlink/pull/219
 [pr222]: https://github.com/ipums/hlink/pull/222
+[pr228]: https://github.com/ipums/hlink/pull/228
 
 [household-matching-docs]: config.html#household-matching
 [household-training-docs]: config.html#household-training-and-model-exploration


### PR DESCRIPTION
Closes #227.

This adds an `hlink.linking.util.set_job_description()` function which you can use as a context manager to update Spark's job description. This is a thread-local variable which is displayed in the Spark UI. I chose a context manager for this because the `SparkContext.setJobDescription()` function sets the description for all following jobs until you call `setJobDescription(None)`. Using a context manager is a simple way to make sure we're doing this everywhere.

I also removed some verbose debug logging and added some more logging in some spots.